### PR TITLE
Upstream Merge #1217 | Stable Language Obfuscation

### DIFF
--- a/Content.Shared/Language/Systems/SharedLanguageSystem.cs
+++ b/Content.Shared/Language/Systems/SharedLanguageSystem.cs
@@ -59,7 +59,10 @@ public abstract class SharedLanguageSystem : EntitySystem
         // Each call would require us to allocate a new instance of random, which would lead to lots of unnecessary calculations.
         // Instead, we use a simple but effective algorithm derived from the C language.
         // It does not produce a truly random number, but for the purpose of obfuscating messages in an RP-based game it's more than alright.
-        seed = seed ^ (_ticker.RoundId * 127);
+        
+        // Floofstation - replaced round-based obfuscation with a persistent one
+        // seed = seed ^ (_ticker.RoundId * 127);
+        seed = seed ^ 0x4813184;
         var random = seed * 1103515245 + 12345;
         return min + Math.Abs(random) % (max - min + 1);
     }


### PR DESCRIPTION
Upstream PR: https://github.com/floof-station/floof-station/pull/1217



-----

# Description
Language obfuscation was made stable across a single round, but varying between rounds. This was mostly a balancing decision to prevent people from simply memorizing every word in a language or using third-party tools to achieve the same. But since Floofstation is a roleplay-focused fork, it is less of an issue here. Allowing people to memorize certain words in foreign languages could lead to interesting roleplay and allow people to literally gradually "learn" a language, albeit only partially.

This will need discussion.

All this PR does is replacing the pseudo-random round-based seed in the RNG with a constant one.

# Changelog
:cl: Vulpstation
- tweak: Words in languages you don't understand should now be obfuscated the same way across all rounds.