### PR TITLE
Dirt and Soil Stuff

### DIFF
--- a/Content.Shared/Maps/TileSystem.cs
+++ b/Content.Shared/Maps/TileSystem.cs
@@ -150,7 +150,9 @@ public sealed class TileSystem : EntitySystem
 
     // Vulp
     public ContentTileDefinition GetBasestTurf(ContentTileDefinition tile) =>
-        _tileDefinitionManager.TryGetDefinition(tile.BaseTurf, out var baseTile)
+        // prevent infinite loops by self-reference
+        // does not prevent longer infinite loops
+        tile.BaseTurf != tile.ID && _tileDefinitionManager.TryGetDefinition(tile.BaseTurf, out var baseTile)
             ? GetBasestTurf((ContentTileDefinition) baseTile)
             : tile;
 

--- a/Content.Shared/Tiles/FloorTileSystem.cs
+++ b/Content.Shared/Tiles/FloorTileSystem.cs
@@ -50,6 +50,10 @@ public sealed class FloorTileSystem : EntitySystem
         if (!args.CanReach || args.Handled)
             return;
 
+        // Vulp: avoid mispredicting tile placement when interacting with entities
+        if (_netManager.IsClient && args.Target != null)
+            return;
+
         if (!TryComp<StackComponent>(uid, out var stack))
             return;
 
@@ -137,7 +141,8 @@ public sealed class FloorTileSystem : EntitySystem
 
                 // Vulp: use basest turf instead of lattice on planets
                 if (currentTileDefinition.BaseTurf == "Lattice"
-                    && baseTurf.BaseTurf == ""
+                    // if no base turf or self-loop
+                    && (baseTurf.BaseTurf == "" || baseTurf.BaseTurf == currentTileDefinition.ID)
                     || HasBaseTurf(currentTileDefinition, baseTurf.ID))
                 {
                     if (!_stackSystem.Use(uid, 1, stack))

--- a/Resources/Locale/en-US/_Vulp/reagents/botany.ftl
+++ b/Resources/Locale/en-US/_Vulp/reagents/botany.ftl
@@ -1,0 +1,2 @@
+reagent-name-plant-matter = plant matter
+reagent-desc-plant-matter = A pulpy mixture of mashed up plants. Nutritious to plants and livestock.

--- a/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/tiles.yml
@@ -924,6 +924,18 @@
       - FloorGrass
   - type: Stack
     stackType: FloorTileGrass
+  # Vulp: nutritious and compostable!
+  - type: Produce
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        reagents:
+        - ReagentId: PlantMatter
+          Quantity: 5 # 10 nutrition per tile seems fine
+  - type: Food
+    requiredStomachs: 2
+  - type: Extractable
+    grindableSolutionName: food
 
 - type: entity
   name: jungle grass tile

--- a/Resources/Prototypes/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/Entities/Structures/soil.yml
@@ -55,3 +55,6 @@
         solution: soil
   - type: Appearance
   - type: PlantHolderVisuals
+  - type: Construction # Vulp
+    graph: Soil
+    node: soil

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -1,7 +1,11 @@
 - type: tile
   id: FloorPlanetDirt
   name: tiles-dirt-floor
-  sprite: /Textures/Tiles/Planet/dirt.rsi/dirt.png
+  sprite: /Textures/_Nuclear14/Tiles/Dirt/dirt.png # Vulp
+  # Vulp: dirt drops dirt, infinitely
+  baseTurf: FloorPlanetDirt
+  canShovel: true
+  itemDrop: Dirt
   isSubfloor: true
   footstepSounds:
     collection: FootstepAsteroid

--- a/Resources/Prototypes/_Vulp/Entities/Objects/Specific/Hydroponics/dirt.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Objects/Specific/Hydroponics/dirt.yml
@@ -1,0 +1,26 @@
+- type: entity
+  name: dirt
+  parent: BaseItem
+  id: Dirt
+  description: "Tastes like dirt."
+  components:
+  - type: Stack
+    stackType: Dirt
+    count: 1
+  - type: Sprite
+    sprite: Objects/Misc/reagent_fillings.rsi
+    state: powderpile
+    color: "#603e2a"
+  - type: Item
+    size: Tiny
+  - type: UserInterface
+    interfaces:
+      enum.RadialSelectorUiKey.Key:
+        type: RadialSelectorMenuBUI
+  - type: ActivatableUI
+    key: enum.RadialSelectorUiKey.Key
+    inHandsOnly: true
+    requireActiveHand: false
+  - type: ShortConstruction
+    entries:
+    - prototype: Soil

--- a/Resources/Prototypes/_Vulp/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Structures/soil.yml
@@ -1,0 +1,8 @@
+- type: entity
+  id: hydroponicsSoilEmpty
+  parent: hydroponicsSoil
+  components:
+  - type: PlantHolder
+    drawWarnings: false
+    waterLevel: 0
+    nutritionLevel: 0

--- a/Resources/Prototypes/_Vulp/Reagents/botany.yml
+++ b/Resources/Prototypes/_Vulp/Reagents/botany.yml
@@ -1,0 +1,15 @@
+- type: reagent
+  id: PlantMatter
+  name: reagent-name-plant-matter
+  group: Botanical
+  desc: reagent-desc-plant-matter
+  physicalDesc: reagent-physical-desc-fibrous
+  flavor: bitter
+  color: "#708600"
+  metabolisms:
+    Food:
+      effects:
+        - !type:SatiateHunger
+  plantMetabolism:
+  - !type:PlantAdjustNutrition
+    amount: 2

--- a/Resources/Prototypes/_Vulp/Recipes/Construction/Graphs/hydroponics.yml
+++ b/Resources/Prototypes/_Vulp/Recipes/Construction/Graphs/hydroponics.yml
@@ -1,0 +1,24 @@
+- type: constructionGraph
+  id: Soil
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: soil
+      steps:
+      - material: Dirt
+        amount: 3
+        doAfter: 2
+
+  - node: soil
+    entity: hydroponicsSoilEmpty
+    edges:
+    - to: start
+      completed:
+      - !type:GivePrototype
+        prototype: Dirt
+        amount: 3
+      - !type:DeleteEntity { }
+      steps:
+      - tool: Digging
+        doAfter: 4

--- a/Resources/Prototypes/_Vulp/Recipes/Construction/hydroponics.yml
+++ b/Resources/Prototypes/_Vulp/Recipes/Construction/hydroponics.yml
@@ -1,0 +1,14 @@
+- type: construction
+  name: soil
+  id: Soil
+  graph: Soil
+  startNode: start
+  targetNode: soil
+  category: construction-category-misc
+  description: "Soil to plant things in."
+  icon:
+    sprite: Structures/Hydroponics/misc.rsi
+    state: soil
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: true

--- a/Resources/Prototypes/_Vulp/Stacks/dirt.yml
+++ b/Resources/Prototypes/_Vulp/Stacks/dirt.yml
@@ -1,0 +1,7 @@
+- type: stack
+  id: Dirt
+  name: dirt
+  icon: { sprite: /Textures/Objects/Misc/reagent_fillings.rsi, state: powderpile, color: "#603e2a" }
+  spawn: Dirt
+  maxCount: 5
+  itemSize: 1


### PR DESCRIPTION
dig dirt tiles to get unlimited dirt
3 dirt to build soil (empty of water and nutrients)
compost grass tiles into soil for nutrients
dig up soil to reclaim dirt

# Changelog
:cl:
- add: Digging dirt now rewards you with dirt, which can be used to craft soil.
- add: Grass tiles can now be composted for nutrients.