### PR TITLE
Upstream Merge #1216 | Fix Mood Being Moody

### DIFF
--- a/Content.Server/Mood/MoodSystem.cs
+++ b/Content.Server/Mood/MoodSystem.cs
@@ -109,8 +109,7 @@ public sealed class MoodSystem : EntitySystem
     private void ApplyEffect(EntityUid uid, MoodComponent component, MoodEffectPrototype prototype, float eventModifier = 1, float eventOffset = 0)
     {
         // Floofstation - cancel any previous timers on this prototype to reset the timeout
-        if (component.CancellationTokens.TryGetValue(prototype.ID, out var token))
-            token.Cancel();
+        var oldToken = component.CancellationTokens.GetValueOrDefault(prototype.ID);
         // ... and create a new one before applying the effect
         var cancelSource = new CancellationTokenSource();
         component.CancellationTokens[prototype.ID] = cancelSource;
@@ -135,14 +134,16 @@ public sealed class MoodSystem : EntitySystem
                 component.CategorisedEffects.Add(prototype.Category, prototype.ID);
 
             // Floof - add cancellation tokens
+            oldToken?.Cancel();
             if (prototype.Timeout != 0)
                 Timer.Spawn(TimeSpan.FromSeconds(prototype.Timeout), () => RemoveTimedOutEffect(uid, prototype.ID, prototype.Category), cancelSource.Token);
         }
         // Apply uncategorised effect
         else
         {
-            if (component.UncategorisedEffects.TryGetValue(prototype.ID, out _))
-                return;
+            // Floofstation - this sucks
+            // if (component.UncategorisedEffects.TryGetValue(prototype.ID, out _))
+            //     return;
 
             var moodChange = prototype.MoodChange * eventModifier + eventOffset;
             if (moodChange == 0)
@@ -155,6 +156,7 @@ public sealed class MoodSystem : EntitySystem
             component.UncategorisedEffects.Add(prototype.ID, moodChange);
 
             // Floof - add cancellation tokens
+            oldToken?.Cancel();
             if (prototype.Timeout != 0)
                 Timer.Spawn(TimeSpan.FromSeconds(prototype.Timeout), () => RemoveTimedOutEffect(uid, prototype.ID), cancelSource.Token);
         }

--- a/Content.Server/Mood/MoodSystem.cs
+++ b/Content.Server/Mood/MoodSystem.cs
@@ -153,7 +153,8 @@ public sealed class MoodSystem : EntitySystem
             if (!component.UncategorisedEffects.ContainsKey(prototype.ID))
                 SendEffectText(uid, prototype);
 
-            component.UncategorisedEffects.Add(prototype.ID, moodChange);
+            // Floof - use setter syntax instead of Add to avoid having that if statement above
+            component.UncategorisedEffects[prototype.ID] = moodChange;
 
             // Floof - add cancellation tokens
             oldToken?.Cancel();


### PR DESCRIPTION
Upstream PR: https://github.com/floof-station/floof-station/pull/1216



-----

# Description
As it turns out, there is ONE code path in ApplyEffect where the effect can not apply under certain conditions (specifically, if you already have an instance of a non-categorized moodlet, it would refuse to add a new one). And my fix for mood flickering involved cancelling the previous timer regardless of whether the new moodlet applied or not (aka whether or not a new timer has started).

This PR aims to fix that issue.



<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/d446ea94-8d25-4ff9-8fe6-290768da6950



</p>
</details>

# Changelog
:cl: EinsteinEngines
- fix: Uncategorized mood effects (such as the "i can't breathe" one) should now properly get removed after their time runs out.