### PR TITLE
Attempt at Making GridAtmosphere Inheit MapAtmosphere

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Atmos.EntitySystems
             tile.GridIndex = owner;
             tile.GridIndices = index;
             // Vulp - new tile, try to apply the map atmosphere
-            if (TryComp<MapAtmosphere>(owner, out var mapAtmos))
+            if (TryComp<MapAtmosphereComponent>(owner, out var mapAtmos))
                 tile.Air.CopyFrom(mapAtmos.Mixture);
             
             return tile;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -42,8 +42,8 @@ namespace Content.Server.Atmos.EntitySystems
             tile.GridIndex = owner;
             tile.GridIndices = index;
             // Vulp - new tile, try to apply the map atmosphere
-            if (TryComp<MapAtmosphereComponent>(owner, out var mapAtmos))
-                tile.Air.CopyFrom(mapAtmos.Mixture);
+            if (TryComp<MapAtmosphereComponent>(owner, out var mapAtmos) && mapAtmos.Mixture is {} mapMixture)
+                tile.Air?.CopyFrom(mapMixture);
             
             return tile;
         }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -41,6 +41,10 @@ namespace Content.Server.Atmos.EntitySystems
 
             tile.GridIndex = owner;
             tile.GridIndices = index;
+            // Vulp - new tile, try to apply the map atmosphere
+            if (TryComp<MapAtmosphere>(owner, out var mapAtmos))
+                tile.Air.CopyFrom(mapAtmos.Mixture);
+            
             return tile;
         }
 


### PR DESCRIPTION
# Description
Made it so that new tiles added to the GridAtmosphere.Tiles have their air mixture set to that of the map atmosphere. Testing needed.

# Changelog
:cl:
- fix: Grid atmosphere should now correctly work on planets.
