### PR TITLE
make grass spread to dirt

### DIFF
--- a/Content.Server/_Vulp/Tiles/TileSpreadComponent.cs
+++ b/Content.Server/_Vulp/Tiles/TileSpreadComponent.cs
@@ -1,0 +1,52 @@
+using Content.Shared.Maps;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+
+namespace Content.Server._Vulp.Tiles;
+
+[RegisterComponent, Access(typeof(TileSpreadSystem))]
+[AutoGenerateComponentPause]
+public sealed partial class TileSpreadComponent : Component
+{
+    /// <summary>
+    /// The next time that tiles will try to spread.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField]
+    public TimeSpan NextUpdate;
+
+    /// <summary>
+    /// How often to try and spread.
+    /// </summary>
+    [DataField]
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(10);
+
+    [DataField(required: true)]
+    public TileSpreadInfo[] Tiles;
+}
+
+[DataDefinition]
+public sealed partial class TileSpreadInfo
+{
+    /// <summary>
+    /// ID of the tile that will spread.
+    /// </summary>
+    [DataField("id", required: true)]
+    public ProtoId<ContentTileDefinition> ID;
+
+    /// <summary>
+    /// IDs of the tiles it can spread to.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<ContentTileDefinition>[] SpreadsTo;
+
+    /// <summary>
+    /// Probability that it will spread (multiplied by number of tiles adjacent).
+    ///
+    /// I'd generally advise decreasing the UpdateInterval rather than increasing this, as it will look weird when
+    /// multiple tiles are spreading at exactly the same time.
+    /// </summary>
+    [DataField]
+    public float Probability = 0.01f;
+}

--- a/Content.Server/_Vulp/Tiles/TileSpreadSystem.cs
+++ b/Content.Server/_Vulp/Tiles/TileSpreadSystem.cs
@@ -1,0 +1,87 @@
+using System.Linq;
+using Content.Server.Atmos.Components;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Vulp.Tiles;
+
+public sealed class TileSpreadSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly MapSystem _map = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileDefs = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    private static Vector2i[] _adjacentTiles = [ Vector2i.Up, Vector2i.Down, Vector2i.Left, Vector2i.Right ];
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TileSpreadComponent, ComponentInit>(OnComponentInit);
+    }
+
+    private void OnComponentInit(EntityUid uid, TileSpreadComponent component, ComponentInit args) =>
+        component.NextUpdate = _gameTiming.CurTime + component.UpdateInterval;
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<TileSpreadComponent, MapGridComponent>();
+        while (query.MoveNext(out var uid, out var tileSpread, out var mapGrid))
+        {
+            if (tileSpread.NextUpdate > _gameTiming.CurTime)
+                continue;
+            tileSpread.NextUpdate += tileSpread.UpdateInterval;
+
+            // track changed tiles so we don't count newly-spread tiles as adjacent
+            var changed = new List<Vector2i>();
+            foreach (var tile in _map.GetAllTiles(uid, mapGrid))
+            {
+                // don't spread under walls
+                if (_map.GetAnchoredEntities(new(uid, mapGrid), tile.GridIndices).Any(HasComp<AirtightComponent>))
+                    continue;
+
+                var chosenTile = tileSpread.Tiles
+                    .Where(info => info.SpreadsTo.Contains(_tileDefs[tile.Tile.TypeId].ID))
+                    .Aggregate(
+                        (id: (string?) null, roll: float.PositiveInfinity),
+                        (candidate, eligible) =>
+                        {
+                            // probability is multiplied by the number of adjacent tiles of the type we want
+                            var probability = _adjacentTiles.Sum(offset =>
+                            {
+                                // if the adjacent tile was just changed, we shouldn't count it
+                                if (changed.Contains(tile.GridIndices + offset))
+                                    return 0.0f;
+
+                                var adjacent = _map.GetTileRef(uid, mapGrid, tile.GridIndices + offset);
+                                if (_tileDefs[adjacent.Tile.TypeId].ID != eligible.ID)
+                                    return 0.0f;
+
+                                return eligible.Probability;
+                            });
+
+                            var roll = _random.NextFloat();
+                            // since multiple eligible tile types might be competing to spread to this one,
+                            // we should give them a fair chance (weighted by spread probability)
+                            if (roll < probability && roll / probability < candidate.roll)
+                                return (eligible.ID, roll / probability);
+
+                            return candidate;
+                        })
+                    .id;
+
+                if (chosenTile is null)
+                    continue;
+
+                _map.SetTile(uid, mapGrid, tile.GridIndices, new(_tileDefs[chosenTile].TileId));
+                changed.Add(tile.GridIndices);
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/_Vulp/Maps/planet.yml
+++ b/Resources/Prototypes/_Vulp/Maps/planet.yml
@@ -17,6 +17,10 @@
         mapLightColor: '#D8B059FF'
         components:
         - type: DayNightCycle
+        - type: TileSpread
+          tiles:
+          - id: FloorPlanetGrass
+            spreadsTo: [ FloorPlanetDirt ]
       - type: StationJobs
         overflowJobs:
         - Passenger


### PR DESCRIPTION
# Description

Grass now spreads to adjacent dirt tiles.

The system can accommodate any number of tile types spreading to any other number of tile types, with configurable (grid-global) frequency and per-tile probability, properly handling cases where two tiles want to spread to the same one.

---

# Changelog

:cl:
- add: Grass now spreads to adjacent dirt tiles!