### PR TITLE
Balancing Tweaks

### DIFF
--- a/Content.Server/Gatherable/Components/GatherableComponent.cs
+++ b/Content.Server/Gatherable/Components/GatherableComponent.cs
@@ -36,4 +36,12 @@ public sealed partial class GatherableComponent : Component
     /// </summary>
     [DataField]
     public float GatherOffset = 0.3f;
+
+    // Vulpstation section
+    /// <summary>
+    ///     How many hits it will take to destroy, assuming gathering efficiency is 1.
+    /// </summary>
+    [DataField]
+    public float Toughness = 2.5f;
+    // Vulpstation section end
 }

--- a/Content.Server/Gatherable/Components/GathererComponent.cs
+++ b/Content.Server/Gatherable/Components/GathererComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server.Gatherable.Components;
+
+
+/// <summary>
+///     Vulpstation - stores the efficiency of a gathering tool (a pickaxe).
+/// </summary>
+[RegisterComponent]
+public sealed partial class GathererComponent : Component
+{
+    [DataField]
+    public float Efficiency = 1f;
+}

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -400,12 +400,12 @@
 
 - type: cargoBounty
   id: BountyTechDisk
-  reward: 25000
+  reward: 10000 # Vulp - what. 25k for this?
   description: bounty-description-tech-disk
   idPrefix: SS13-
   entries:
   - name: bounty-item-tech-disk
-    amount: 5
+    amount: 10
     whitelist:
       components:
       - TechnologyDisk
@@ -457,11 +457,11 @@
 
 - type: cargoBounty
   id: BountyArtifactFragment
-  reward: 32500
+  reward: 10000 # Vulp - no
   description: bounty-description-artifact-fragment
   entries:
   - name: bounty-item-artifact-fragment
-    amount: 7
+    amount: 14 # Vulp - planetside, fragments are worth less
     whitelist:
       tags:
       - ArtifactFragment

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -50,7 +50,7 @@
     tags:
     - Pickaxe
   - type: Gatherer # Vulpstation - less than a pick, but ends up being better due to faster attack rate.
-    efficiency: 0.3
+    efficiency: 0.37
   - type: Sprite
     sprite: Objects/Tools/handdrill.rsi
     state: handdrill
@@ -94,6 +94,8 @@
     heavyStaminaCost: 0 #floof
   - type: DamageOtherOnHit #floof
     staminaCost: 8
+  - type: Gatherer # Vulpstation
+    efficiency: 0.6 # Better than a normal drill
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -7,6 +7,8 @@
   - type: Tag
     tags:
     - Pickaxe
+  - type: Gatherer # Vulpstation
+    efficiency: 1
   - type: Sprite
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
@@ -47,6 +49,8 @@
   - type: Tag
     tags:
     - Pickaxe
+  - type: Gatherer # Vulpstation - less than a pick, but ends up being better due to faster attack rate.
+    efficiency: 0.3
   - type: Sprite
     sprite: Objects/Tools/handdrill.rsi
     state: handdrill

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -71,7 +71,7 @@
 
 - type: entity
   id: AsteroidRockGold
-  parent: AsteroidRock
+  parent: [GatherableTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -93,7 +93,7 @@
 
 - type: entity
   id: AsteroidRockDiamond
-  parent: AsteroidRock
+  parent: [GatherableVeryTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with diamonds.
   suffix: Diamond
   components:
@@ -115,7 +115,7 @@
 
 - type: entity
   id: AsteroidRockPlasma
-  parent: AsteroidRock
+  parent: [GatherableTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -137,7 +137,7 @@
 
 - type: entity
   id: AsteroidRockQuartz
-  parent: AsteroidRock
+  parent: [GatherableTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with quartz.
   suffix: Quartz
   components:
@@ -181,7 +181,7 @@
 
 - type: entity
   id: AsteroidRockSilver
-  parent: AsteroidRock
+  parent: [GatherableTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -213,7 +213,7 @@
 # Yes I know it drops steel but we may get smelting at some point
 - type: entity
   id: AsteroidRockTin
-  parent: AsteroidRock
+  parent: [GatherableTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with iron.
   suffix: Iron
   components:
@@ -244,7 +244,7 @@
 
 - type: entity
   id: AsteroidRockUranium
-  parent: AsteroidRock
+  parent: [GatherableVeryTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -275,7 +275,7 @@
 
 - type: entity
   id: AsteroidRockBananium
-  parent: AsteroidRock
+  parent: [GatherableVeryTough, AsteroidRock] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -297,7 +297,7 @@
 
 - type: entity
   id: AsteroidRockArtifactFragment
-  parent: AsteroidRock
+  parent: [GatherableVeryTough, AsteroidRock] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -319,7 +319,7 @@
 
 - type: entity
   id: AsteroidRockBluespace
-  parent: AsteroidRock
+  parent: [GatherableVeryTough, AsteroidRock] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -341,7 +341,7 @@
 
 - type: entity
   id: AsteroidRockNormality
-  parent: AsteroidRock
+  parent: [GatherableVeryTough, AsteroidRock] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:
@@ -441,6 +441,7 @@
       noRot: true
     - type: SoundOnGather
     - type: Gatherable
+      toughness: 2.5
       toolWhitelist:
         tags:
           - Pickaxe
@@ -481,7 +482,7 @@
 # Ore veins
 - type: entity
   id: WallRockCoal
-  parent: WallRock
+  parent: [GatherableTough, WallRock] # Vulpstation
   description: An ore vein rich with coal.
   suffix: Coal
   components:
@@ -503,7 +504,7 @@
 
 - type: entity
   id: WallRockGold
-  parent: WallRock
+  parent: [GatherableTough, WallRock] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -547,7 +548,7 @@
 
 - type: entity
   id: WallRockPlasma
-  parent: WallRock
+  parent: [GatherableTough, WallRock] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -591,7 +592,7 @@
 
 - type: entity
   id: WallRockSilver
-  parent: WallRock
+  parent: [GatherableTough, WallRock] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -636,7 +637,7 @@
 
 - type: entity
   id: WallRockUranium
-  parent: WallRock
+  parent: [GatherableVeryTough, WallRock] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -659,7 +660,7 @@
 
 - type: entity
   id: WallRockBananium
-  parent: WallRock
+  parent: [GatherableVeryTough, WallRock] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -681,7 +682,7 @@
 
 - type: entity
   id: WallRockArtifactFragment
-  parent: WallRock
+  parent: [GatherableVeryTough, WallRock] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -725,7 +726,7 @@
 
 - type: entity
   id: WallRockBluespace
-  parent: WallRock
+  parent: [GatherableVeryTough, WallRock] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -747,7 +748,7 @@
 
 - type: entity
   id: WallRockNormality
-  parent: WallRock
+  parent: [GatherableVeryTough, WallRock] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:
@@ -813,7 +814,7 @@
 
 - type: entity
   id: WallRockBasaltGold
-  parent: WallRockBasalt
+  parent: [GatherableTough, WallRockBasalt] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -857,7 +858,7 @@
 
 - type: entity
   id: WallRockBasaltPlasma
-  parent: WallRockBasalt
+  parent: [GatherableTough, WallRockBasalt] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -901,7 +902,7 @@
 
 - type: entity
   id: WallRockBasaltSilver
-  parent: WallRockBasalt
+  parent: [GatherableTough, WallRockBasalt] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -945,7 +946,7 @@
 
 - type: entity
   id: WallRockBasaltUranium
-  parent: WallRockBasalt
+  parent: [GatherableVeryTough, WallRockBasalt] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -968,7 +969,7 @@
 
 - type: entity
   id: WallRockBasaltBananium
-  parent: WallRockBasalt
+  parent: [GatherableVeryTough, WallRockBasalt] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -990,7 +991,7 @@
 
 - type: entity
   id: WallRockBasaltArtifactFragment
-  parent: WallRockBasalt
+  parent: [GatherableVeryTough, WallRockBasalt] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -1034,7 +1035,7 @@
 
 - type: entity
   id: WallRockBasaltBluespace
-  parent: WallRockBluespace
+  parent: [GatherableVeryTough, WallRockBluespace] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -1056,7 +1057,7 @@
 
 - type: entity
   id: WallRockBasaltNormality
-  parent: WallRockNormality
+  parent: [GatherableVeryTough, WallRockNormality] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:
@@ -1122,7 +1123,7 @@
 
 - type: entity
   id: WallRockSnowGold
-  parent: WallRockSnow
+  parent: [GatherableTough, WallRockSnow] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -1166,7 +1167,7 @@
 
 - type: entity
   id: WallRockSnowPlasma
-  parent: WallRockSnow
+  parent: [GatherableTough, WallRockSnow] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -1210,7 +1211,7 @@
 
 - type: entity
   id: WallRockSnowSilver
-  parent: WallRockSnow
+  parent: [GatherableTough, WallRockSnow] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -1254,7 +1255,7 @@
 
 - type: entity
   id: WallRockSnowUranium
-  parent: WallRockSnow
+  parent: [GatherableVeryTough, WallRockSnow] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -1277,7 +1278,7 @@
 
 - type: entity
   id: WallRockSnowBananium
-  parent: WallRockSnow
+  parent: [GatherableVeryTough, WallRockSnow] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -1299,7 +1300,7 @@
 
 - type: entity
   id: WallRockSnowArtifactFragment
-  parent: WallRockSnow
+  parent: [GatherableVeryTough, WallRockSnow] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -1343,7 +1344,7 @@
 
 - type: entity
   id: WallRockSnowBluespace
-  parent: WallRockSnow
+  parent: [GatherableVeryTough, WallRockSnow] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -1365,7 +1366,7 @@
 
 - type: entity
   id: WallRockSnowNormality
-  parent: WallRockSnow
+  parent: [GatherableVeryTough, WallRockSnow] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:
@@ -1431,7 +1432,7 @@
 
 - type: entity
   id: WallRockSandGold
-  parent: WallRockSand
+  parent: [GatherableTough, WallRockSand] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -1475,7 +1476,7 @@
 
 - type: entity
   id: WallRockSandPlasma
-  parent: WallRockSand
+  parent: [GatherableTough, WallRockSand] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -1519,7 +1520,7 @@
 
 - type: entity
   id: WallRockSandSilver
-  parent: WallRockSand
+  parent: [GatherableTough, WallRockSand] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -1563,7 +1564,7 @@
 
 - type: entity
   id: WallRockSandUranium
-  parent: WallRockSand
+  parent: [GatherableVeryTough, WallRockSand] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -1585,7 +1586,7 @@
 
 - type: entity
   id: WallRockSandBananium
-  parent: WallRockSand
+  parent: [GatherableVeryTough, WallRockSand] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -1607,7 +1608,7 @@
 
 - type: entity
   id: WallRockSandArtifactFragment
-  parent: WallRockSand
+  parent: [GatherableVeryTough, WallRockSand] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -1651,7 +1652,7 @@
 
 - type: entity
   id: WallRockSandBluespace
-  parent: WallRockSand
+  parent: [GatherableVeryTough, WallRockSand] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -1673,7 +1674,7 @@
 
 - type: entity
   id: WallRockSandNormality
-  parent: WallRockSand
+  parent: [GatherableVeryTough, WallRockSand] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:
@@ -1739,7 +1740,7 @@
 
 - type: entity
   id: WallRockChromiteGold
-  parent: WallRockChromite
+  parent: [GatherableTough, WallRockChromite] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -1783,7 +1784,7 @@
 
 - type: entity
   id: WallRockChromitePlasma
-  parent: WallRockChromite
+  parent: [GatherableTough, WallRockChromite] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -1827,7 +1828,7 @@
 
 - type: entity
   id: WallRockChromiteSilver
-  parent: WallRockChromite
+  parent: [GatherableTough, WallRockChromite] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -1871,7 +1872,7 @@
 
 - type: entity
   id: WallRockChromiteUranium
-  parent: WallRockChromite
+  parent: [GatherableVeryTough, WallRockChromite] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -1894,7 +1895,7 @@
 
 - type: entity
   id: WallRockChromiteBananium
-  parent: WallRockChromite
+  parent: [GatherableVeryTough, WallRockChromite] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -1916,7 +1917,7 @@
 
 - type: entity
   id: WallRockChromiteArtifactFragment
-  parent: WallRockChromite
+  parent: [GatherableVeryTough, WallRockChromite] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -1960,7 +1961,7 @@
 
 - type: entity
   id: WallRockChromiteBluespace
-  parent: WallRockChromite
+  parent: [GatherableVeryTough, WallRockChromite] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -1982,7 +1983,7 @@
 
 - type: entity
   id: WallRockChromiteNormality
-  parent: WallRockChromite
+  parent: [GatherableVeryTough, WallRockChromite] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:
@@ -2048,7 +2049,7 @@
 
 - type: entity
   id: WallRockAndesiteGold
-  parent: WallRockAndesite
+  parent: [GatherableTough, WallRockAndesite] # Vulpstation
   description: An ore vein rich with gold.
   suffix: Gold
   components:
@@ -2092,7 +2093,7 @@
 
 - type: entity
   id: WallRockAndesitePlasma
-  parent: WallRockAndesite
+  parent: [GatherableTough, WallRockAndesite] # Vulpstation
   description: An ore vein rich with plasma.
   suffix: Plasma
   components:
@@ -2136,7 +2137,7 @@
 
 - type: entity
   id: WallRockAndesiteSilver
-  parent: WallRockAndesite
+  parent: [GatherableTough, WallRockAndesite] # Vulpstation
   description: An ore vein rich with silver.
   suffix: Silver
   components:
@@ -2180,7 +2181,7 @@
 
 - type: entity
   id: WallRockAndesiteUranium
-  parent: WallRockAndesite
+  parent: [GatherableVeryTough, WallRockAndesite] # Vulpstation
   description: An ore vein rich with uranium.
   suffix: Uranium
   components:
@@ -2203,7 +2204,7 @@
 
 - type: entity
   id: WallRockAndesiteBananium
-  parent: WallRockAndesite
+  parent: [GatherableVeryTough, WallRockAndesite] # Vulpstation
   description: An ore vein rich with bananium.
   suffix: Bananium
   components:
@@ -2225,7 +2226,7 @@
 
 - type: entity
   id: WallRockAndesiteArtifactFragment
-  parent: WallRockAndesite
+  parent: [GatherableVeryTough, WallRockAndesite] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Artifact Fragment
   components:
@@ -2269,7 +2270,7 @@
 
 - type: entity
   id: WallRockAndesiteBluespace
-  parent: WallRockAndesite
+  parent: [GatherableVeryTough, WallRockAndesite] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Bluespace
   components:
@@ -2291,7 +2292,7 @@
 
 - type: entity
   id: WallRockAndesiteNormality
-  parent: WallRockAndesite
+  parent: [GatherableVeryTough, WallRockAndesite] # Vulpstation
   description: A rock wall. What's that sticking out of it?
   suffix: Normality
   components:

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -474,6 +474,9 @@
           state: rock_north
         - map: [ "enum.EdgeLayer.West" ]
           state: rock_west
+    - type: Construction # Vulpstation
+      graph: Rock
+      node: rock
 
 # Ore veins
 - type: entity

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -124,7 +124,7 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/materials.rsi, state: bluespace }
   color: "#53a9ff"
-  price: 7.5
+  price: 3 # Vulp - not as expensive
 
 - type: material
   id: Normality
@@ -133,7 +133,7 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/materials.rsi, state: normality }
   color: "#53a9ff"
-  price: 7.5
+  price: 3 # Vulp - not as expensive
 
 - type: material
   id: Gunpowder
@@ -149,4 +149,4 @@
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/materials.rsi, state: diamond }
   color: "#80ffff"
-  price: 20 # big diamond gaslit us so hard diamonds actually became extremely rare
+  price: 1.5 # big diamond gaslit us so hard diamonds actually became extremely rare # Floof - yes

--- a/Resources/Prototypes/_Floof/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Bounties/bounties.yml
@@ -2,7 +2,7 @@
 
 - type: cargoBounty
   id: BountyDiamond
-  reward: 80000
+  reward: 10000 # Vulp - just, no
   description: bounty-description-diamond
   entries:
   - name: bounty-item-diamond

--- a/Resources/Prototypes/_Vulp/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Structures/Walls/asteroid.yml
@@ -1,0 +1,15 @@
+# For ore veins
+- type: entity
+  id: GatherableTough
+  parent: WallRock
+  components:
+  - type: Gatherable
+    toughness: 4
+
+# For extra hard rocks, such as diamonds
+- type: entity
+  id: GatherableVeryTough
+  parent: WallRock
+  components:
+  - type: Gatherable
+    toughness: 6

--- a/Resources/Prototypes/_Vulp/Recipes/Construction/rocks.yml
+++ b/Resources/Prototypes/_Vulp/Recipes/Construction/rocks.yml
@@ -1,0 +1,45 @@
+- type: construction
+  name: Rock
+  id: Rock
+  graph: Rock
+  startNode: start
+  targetNode: rock
+  category: construction-category-misc
+  description: A rock, for decoration!
+  icon: { sprite: Structures/Walls/rock.rsi, state: rock }
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canRotate: false
+  canBuildInImpassable: false
+  conditions:
+  - !type:TileNotBlocked
+
+- type: constructionGraph
+  id: Rock
+  start: start
+  graph:
+  - node: start
+    actions:
+    - !type:DestroyEntity { }
+    edges:
+    - to: rock
+      completed:
+      - !type:SnapToGrid { }
+      steps:
+      - material: Steel
+        amount: 10
+        doAfter: 5
+
+  - node: rock
+    entity: WallRock
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 10
+      steps:
+      - tool: Prying
+        doAfter: 3
+      - tool: Screwing
+        doAfter: 2


### PR DESCRIPTION
# Description
Made rocks take up to 2.5 pickaxe hits to break (more with mining drills but ends up faster due to their higher attack rates), with ores taking up even more.

Made rocks constructible.
Made diamonds not cost an obscene amount when selling
Reduced the revenues from some of the extremely profitable bounties

# Changelog
:cl:
- tweak: Rocks can now take more than 1 hit to destroy. You can no longer just clear out the world with a single pickaxe.
- tweak: Diamonds are no longer worth 60k/stack, and some of the obscenely profitable cargo bounties now yield less money.
