### PR TITLE
Fix Grid Atmos (This Time for Real)

### DIFF
--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -276,7 +276,7 @@ namespace Content.IntegrationTests.Tests
                 if (protoId == "StandardNanotrasenStation")
                     continue;
 
-                if (server.ProtoMan.Index<EntityPrototype>(protoId).HasComponent<StationDataComponent>())
+                if (server.ProtoMan.Index<EntityPrototype>(protoId).Components.ContainsKey("StationData"))
                     continue; // vulp - makes no sense to test spawning a station
 
                 var count = server.EntMan.EntityCount;

--- a/Content.IntegrationTests/Tests/EntityTest.cs
+++ b/Content.IntegrationTests/Tests/EntityTest.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Content.Server.Station.Components;
+using Content.Shared.Prototypes;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Log;
 using Robust.Shared.Map;
 using Robust.Shared.Maths;
@@ -272,6 +275,9 @@ namespace Content.IntegrationTests.Tests
                 // Fails due to audio components made when making anouncements
                 if (protoId == "StandardNanotrasenStation")
                     continue;
+
+                if (server.ProtoMan.Index<EntityPrototype>(protoId).HasComponent<StationDataComponent>())
+                    continue; // vulp - makes no sense to test spawning a station
 
                 var count = server.EntMan.EntityCount;
                 var clientCount = client.EntMan.EntityCount;

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Commands.cs
@@ -4,6 +4,7 @@ using Content.Server.Atmos.Components;
 using Content.Shared.Administration;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
+using Content.Shared.Parallax.Biomes;
 using Robust.Shared.Console;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -89,6 +90,10 @@ public sealed partial class AtmosphereSystem
            // Force Invalidate & update air on all tiles
            Entity<GridAtmosphereComponent, GasTileOverlayComponent, MapGridComponent, TransformComponent> grid =
                new(euid.Value, gridAtmosphere, Comp<GasTileOverlayComponent>(euid.Value), gridComp, Transform(euid.Value));
+
+           // Vulpstation - clear unloaded biomes
+           if (TryComp<BiomeComponent>(grid, out var biome))
+               biome.ModifiedAtmos = new();
 
            RebuildGridTiles(grid);
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -30,7 +30,8 @@ namespace Content.Server.Atmos.EntitySystems
         private int _currentRunAtmosphereIndex;
         private bool _simulationPaused;
 
-        private TileAtmosphere GetOrNewTile(EntityUid owner, GridAtmosphereComponent atmosphere, Vector2i index, bool invalidateNew = true)
+        // Vulpstation - made public
+        public TileAtmosphere GetOrNewTile(EntityUid owner, GridAtmosphereComponent atmosphere, Vector2i index, bool invalidateNew = true)
         {
             var tile = atmosphere.Tiles.GetOrNew(index, out var existing);
             if (existing)
@@ -44,7 +45,7 @@ namespace Content.Server.Atmos.EntitySystems
             // Vulp - new tile, try to apply the map atmosphere
             if (TryComp<MapAtmosphereComponent>(owner, out var mapAtmos) && mapAtmos.Mixture is {} mapMixture)
                 tile.Air?.CopyFrom(mapMixture);
-            
+
             return tile;
         }
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -44,7 +44,10 @@ namespace Content.Server.Atmos.EntitySystems
             tile.GridIndices = index;
             // Vulp - new tile, try to apply the map atmosphere
             if (TryComp<MapAtmosphereComponent>(owner, out var mapAtmos) && mapAtmos.Mixture is {} mapMixture)
+            {
+                tile.Air = new();
                 tile.Air?.CopyFrom(mapMixture);
+            }
 
             return tile;
         }

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -52,9 +52,9 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
     private EntityQuery<BiomeComponent> _biomeQuery;
     private EntityQuery<FixturesComponent> _fixturesQuery;
     private EntityQuery<TransformComponent> _xformQuery;
-    private EntityQuery<GhostComponent> _ghostQuery;
-    private EntityQuery<GridAtmosphereComponent> _gridAtmosQuery;
-    private EntityQuery<MapAtmosphereComponent> _mapAtmosQuery;
+    private EntityQuery<GhostComponent> _ghostQuery; // Vulpstation
+    private EntityQuery<GridAtmosphereComponent> _gridAtmosQuery; // Vulpstation
+    private EntityQuery<MapAtmosphereComponent> _mapAtmosQuery; // Vulpstation
 
     private readonly HashSet<EntityUid> _handledEntities = new();
     private const float DefaultLoadRange = 16f;
@@ -89,8 +89,8 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         _fixturesQuery = GetEntityQuery<FixturesComponent>();
         _xformQuery = GetEntityQuery<TransformComponent>();
         _ghostQuery = GetEntityQuery<GhostComponent>(); // Vulpstation
-        _mapAtmosQuery = GetEntityQuery<MapAtmosphereComponent>();
-        _gridAtmosQuery = GetEntityQuery<GridAtmosphereComponent>();
+        _mapAtmosQuery = GetEntityQuery<MapAtmosphereComponent>(); // Vulpstation
+        _gridAtmosQuery = GetEntityQuery<GridAtmosphereComponent>(); // Vulpstation
         SubscribeLocalEvent<BiomeComponent, MapInitEvent>(OnBiomeMapInit);
         SubscribeLocalEvent<FTLStartedEvent>(OnFTLStarted);
         SubscribeLocalEvent<ShuttleFlattenEvent>(OnShuttleFlatten);
@@ -328,6 +328,10 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         // Get chunks in range
         foreach (var pSession in Filter.GetAllPlayers(_playerManager))
         {
+            // Vulp - don't allow ghosts to generate terrain, except admin ghosts
+            if (_ghostQuery.TryComp(pSession.AttachedEntity, out var ghost) && !ghost.CanGhostInteract)
+                continue;
+
             if (_xformQuery.TryGetComponent(pSession.AttachedEntity, out var xform) &&
                 _handledEntities.Add(pSession.AttachedEntity.Value) &&
                  _biomeQuery.TryGetComponent(xform.MapUid, out var biome) &&
@@ -346,7 +350,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
             foreach (var viewer in pSession.ViewSubscriptions)
             {
                 if (!_handledEntities.Add(viewer) ||
-                    _ghostQuery.TryComp(viewer, out var ghost) && !ghost.CanGhostInteract || // Vulp - don't allow ghosts to generate terrain, except admin ghosts
+                    _ghostQuery.TryComp(viewer, out ghost) && !ghost.CanGhostInteract || // Vulp - don't allow ghosts to generate terrain, except admin ghosts
                     !_xformQuery.TryGetComponent(viewer, out xform) ||
                     !_biomeQuery.TryGetComponent(xform.MapUid, out biome) ||
                     !biome.Enabled)

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -762,20 +762,11 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         _tiles.Clear();
 
         // Set tiles first
-        var oldChunkAtmos = component.ModifiedAtmos.GetValueOrDefault(chunk); // Vulpstation
-        var gridAtmos = _gridAtmosQuery.CompOrNull(gridUid); // Vulpstation
-        var defaultMix = _mapAtmosQuery.CompOrNull(gridUid)?.Mixture; // Vulpstation
         for (var x = 0; x < ChunkSize; x++)
         {
             for (var y = 0; y < ChunkSize; y++)
             {
                 var indices = new Vector2i(x + chunk.X, y + chunk.Y);
-
-                // Vulpstation - set tile atmos first
-                if (gridAtmos != null && oldChunkAtmos != null && oldChunkAtmos.TryGetValue(indices, out var oldMix))
-                    _atmos.GetOrNewTile(gridUid, gridAtmos, indices)?.Air?.CopyFrom(oldMix);
-                else if (gridAtmos != null && defaultMix != null)
-                    _atmos.GetOrNewTile(gridUid, gridAtmos, indices)?.Air?.CopyFrom(defaultMix);
 
                 // Pass in null so we don't try to get the tileref.
                 if (modified.Contains(indices))
@@ -799,11 +790,20 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         var loadedEntities = new Dictionary<EntityUid, Vector2i>();
         component.LoadedEntities.Add(chunk, loadedEntities);
 
+        var oldChunkAtmos = component.ModifiedAtmos.GetValueOrDefault(chunk); // Vulpstation
+        var gridAtmos = _gridAtmosQuery.CompOrNull(gridUid); // Vulpstation
+        var defaultMix = _mapAtmosQuery.CompOrNull(gridUid)?.Mixture; // Vulpstation
         for (var x = 0; x < ChunkSize; x++)
         {
             for (var y = 0; y < ChunkSize; y++)
             {
                 var indices = new Vector2i(x + chunk.X, y + chunk.Y);
+
+                // Vulpstation - set tile atmos first. This has to be done AFTER tiles are placed.
+                if (gridAtmos != null && oldChunkAtmos != null && oldChunkAtmos.TryGetValue(indices, out var oldMix))
+                    _atmos.GetOrNewTile(gridUid, gridAtmos, indices)?.Air?.CopyFrom(oldMix);
+                else if (gridAtmos != null && defaultMix != null)
+                    _atmos.GetOrNewTile(gridUid, gridAtmos, indices)?.Air?.CopyFrom(defaultMix);
 
                 if (modified.Contains(indices))
                     continue;

--- a/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.cs
+++ b/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._Vulp.Station.Components;
+using Content.Server.Atmos.Components;
 using Content.Server.Parallax;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
@@ -40,6 +41,8 @@ public sealed partial class PlanetStationSystem : EntitySystem
         var mapUid = _mapManager.GetMapEntityIdOrThrow(mapId);
 
         _biome.EnsurePlanet(mapUid, _proto.Index(map.Comp.Biome), map.Comp.Seed, mapLight: map.Comp.MapLightColor);
+
+        EnsureComp<GridAtmosphereComponent>(mapUid); // Pray to god the map also has a MapAtmosphereComponent
 
         // stolen from salvage gateway generation
         const string planetNames = "names_borer";

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -302,5 +302,20 @@ namespace Content.Shared.Atmos
             };
             return newMixture;
         }
+
+        // Vulpstation
+        public bool ApproximatelyEqual(GasMixture other)
+        {
+            if (Math.Abs(Temperature - other.Temperature) > 0.01f)
+                return false;
+
+            for (var i = 0; i < Atmospherics.AdjustedNumberOfGases; i++)
+            {
+                if (Math.Abs(Moles[i] - other.Moles[i]) > 0.01f)
+                    return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -303,15 +303,15 @@ namespace Content.Shared.Atmos
             return newMixture;
         }
 
-        // Vulpstation
+        // Vulpstation - this is primarily for use in the BiomeSystem, that's why it's so permissive.
         public bool ApproximatelyEqual(GasMixture other)
         {
-            if (Math.Abs(Temperature - other.Temperature) > 0.01f)
+            if (Math.Abs(Temperature - other.Temperature) > 2f)
                 return false;
 
             for (var i = 0; i < Atmospherics.AdjustedNumberOfGases; i++)
             {
-                if (Math.Abs(Moles[i] - other.Moles[i]) > 0.01f)
+                if (Math.Abs(Moles[i] - other.Moles[i]) > 0.5f)
                     return false;
             }
 

--- a/Content.Shared/Parallax/Biomes/BiomeComponent.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Atmos;
 using Content.Shared.Parallax.Biomes.Layers;
 using Content.Shared.Parallax.Biomes.Markers;
 using Robust.Shared.GameStates;
@@ -45,6 +46,11 @@ public sealed partial class BiomeComponent : Component
     /// </summary>
     [DataField("modifiedTiles")]
     public Dictionary<Vector2i, HashSet<Vector2i>> ModifiedTiles = new();
+
+    // Vulpstation
+    /// All modified atmos in this chunk.
+    [DataField, Access(Other = AccessPermissions.ReadWriteExecute)]
+    public Dictionary<Vector2i, Dictionary<Vector2i, GasMixture>> ModifiedAtmos = new();
 
     /// <summary>
     /// Decals that have been loaded as a part of this biome.

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -117,16 +117,16 @@
       effects:
       - !type:ActivateArtifact
 
-#- type: artifactTrigger
-#  id: TriggerGas
-#  targetDepth: 2
-#  triggerHint: artifact-trigger-hint-regular-gases
-#components:
-#- type: ArtifactGasTrigger
-#possibleGas:
-#- Oxygen
-#- Nitrogen
-#- CarbonDioxide
+- type: artifactTrigger
+  id: TriggerGas
+  targetDepth: 2
+  triggerHint: artifact-trigger-hint-regular-gases
+  components:
+  - type: ArtifactGasTrigger
+    possibleGas:
+    - Oxygen
+    - Nitrogen
+    - CarbonDioxide
 
 - type: artifactTrigger
   id: TriggerDeath
@@ -142,13 +142,13 @@
   components:
   - type: ArtifactMagnetTrigger
 
-#- type: artifactTrigger
- # id: TriggerLowPressure
- # targetDepth: 2
- # triggerHint: artifact-trigger-hint-pressure
- # components:
- # - type: ArtifactPressureTrigger
-#  minPressureThreshold: 50
+- type: artifactTrigger
+  id: TriggerLowPressure
+  targetDepth: 2
+  triggerHint: artifact-trigger-hint-pressure
+  components:
+  - type: ArtifactPressureTrigger
+    minPressureThreshold: 50
 
 - type: artifactTrigger
   id: TriggerHighDamage
@@ -170,22 +170,22 @@
     damageThreshold: 50
   - type: RadiationReceiver
 
-# - type: artifactTrigger
-#  id: TriggerHighPressure
-#  targetDepth: 3
-#  triggerHint: artifact-trigger-hint-pressure
-#  components:
-#  - type: ArtifactPressureTrigger
-#    maxPressureThreshold: 385
+- type: artifactTrigger
+  id: TriggerHighPressure
+  targetDepth: 3
+  triggerHint: artifact-trigger-hint-pressure
+  components:
+  - type: ArtifactPressureTrigger
+    maxPressureThreshold: 385
 
-#- type: artifactTrigger
-#  id: TriggerPlasma
-#  targetDepth: 3
-#  triggerHint: artifact-trigger-hint-plasma
-#  components:
-#  - type: ArtifactGasTrigger
-#    possibleGas:
-#    - Plasma
+- type: artifactTrigger
+  id: TriggerPlasma
+  targetDepth: 3
+  triggerHint: artifact-trigger-hint-plasma
+  components:
+  - type: ArtifactGasTrigger
+    possibleGas:
+    - Plasma
 
 #don't add in new targetdepth values until you have a few
 #or else it will skew heavily towards a few options.


### PR DESCRIPTION
# Description
Followup to #13, this time I updated the BiomeSystem which is responsible for splitting the map into chunks, loading and unloading them. Turns out the system literally deletes all tiles that have the default biome content on them (unmodied tile, no anchored entities, no decals) when unloading a chunk, which consequently deletes atmos on them. But when loading them back, the system neither tries to restore the old atmos nor tries to provide fallback, it just creates tiles without atmosphere (vacuum).

This fixes the issue by actually making the BiomeSystem save modified atmos (only on tiles that have atmos significantly different from MapAtmosphere's) when unloading chunks and restore them when loading them back. Additionally this makes the fixgridatmos command erase atmos chunk data.

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/847d4308-4f79-4e68-83eb-07e0db309259



</p>
</details>

# Changelog
:cl:
- fix: Grid atmos work on planets now! Atmospheric technicians and xenoarcheologists, rejoice!
- tweak: Ghosts (non-admin ones) will no longer cause terrain to load or generate when flying around.
