### PR TITLE
Fix Weird Atmos Bug

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AirtightSystem.cs
@@ -45,7 +45,8 @@ namespace Content.Server.Atmos.EntitySystems
             var xform = Transform(airtight);
 
             // If the grid is deleting no point updating atmos.
-            if (xform.GridUid != null && LifeStage(xform.GridUid.Value) <= EntityLifeStage.MapInitialized)
+            // Vulpstation - this used to skip update if the grid IS POST MAP INIT, not post termination. Fixed the issue.
+            if (xform.GridUid != null && LifeStage(xform.GridUid.Value) <= EntityLifeStage.Terminating)
                 SetAirblocked(airtight, false, xform);
         }
 


### PR DESCRIPTION
# Description
The AirtightSystem would refuse to update the airtight status of a soon-to-be-deleted airtight entity if the grid it's on is post-map-init. The original comment suggested it's only supposed to refuse if the grid is post-termination. Blegh. This bug has been there forever but didn't affected non-planet grid atmos.

# Changelog
:cl:
- fix: Fixed an ages-old bug in the airight system that would leave a tile airtight even after the anchored airtight entity has been removed from it (e.g. a rock was mined up).