### PR TITLE
Shuttle Vote

### DIFF
--- a/Content.Shared/_Vulp/VulpCCVars.cs
+++ b/Content.Shared/_Vulp/VulpCCVars.cs
@@ -1,0 +1,22 @@
+using Robust.Shared;
+using Robust.Shared.Configuration;
+
+
+namespace Content.Shared._Vulp;
+
+
+[CVarDefs]
+public sealed class VulpCCVars
+{
+    /// <summary>
+    ///     Whether to start a public vote before automatically sending the emergency shuttle.
+    /// </summary>
+    public static readonly CVarDef<bool> DoEvacVotes =
+        CVarDef.Create("shuttle.emergency_do_evac_votes", true, CVar.SERVER);
+
+    /// <summary>
+    ///     The duration of the public vote before automatically sending the emergency shuttle.
+    /// </summary>
+    public static readonly CVarDef<float> EvacVoteDuration =
+        CVarDef.Create("shuttle.emergency_vote_duration", 120f, CVar.SERVER);
+}

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -8,3 +8,7 @@ round-end-system-round-restart-eta-announcement = Restarting the round in {$time
 
 eta-units-minutes = minutes
 eta-units-seconds = seconds
+
+# Vulpstation
+round-end-system-shuttle-call-vote = Call the emergency shuttle (end the shift)?
+round-end-system-shuttle-call-vote-initiator = Central Command


### PR DESCRIPTION
# Description
Makes the server call an evac vote instead of forcing command players to do it.

<details><summary><h1>Media</h1></summary>
<p>


https://github.com/user-attachments/assets/38573a14-ce24-48f5-bc3c-ecbf972a93b6


</p>
</details>

# Changelog
:cl:
- add: The server will now automatically call an evac vote when the round is about to reach its standard end time.
