### PR TITLE
Balancing patches and minor changes

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -96,6 +96,10 @@ public sealed partial class AnomalySystem
         var targetCoords = xform.Coordinates;
         var gridBounds = gridComp.LocalAABB.Scale(_configuration.GetCVar(CCVars.AnomalyGenerationGridBoundsScale));
 
+        // Vulpstation - if grid bounds are zero, enlarge them artificially
+        if (gridBounds.Size == Vector2.Zero)
+            gridBounds = new Box2(new Vector2(-50, -50), new Vector2(50, 50));
+
         for (var i = 0; i < 25; i++)
         {
             var randomX = Random.Next((int) gridBounds.Left, (int) gridBounds.Right);

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -761,7 +761,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (SubtleOOCRespectsLOS && !data.InLOS)
                 continue; // Floofstation: some things dont go through walls (but they go through windows!)
 
-            _chatManager.ChatMessageToOne(ChatChannel.Emotes, action, wrappedMessage, source, false, session.Channel);
+            _chatManager.ChatMessageToOne(ChatChannel.Subtle, action, wrappedMessage, source, false, session.Channel);
         }
 
         if (!hideLog)

--- a/Content.Server/StationEvents/Components/VentCritterSpawnLocationComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCritterSpawnLocationComponent.cs
@@ -5,5 +5,6 @@ namespace Content.Server.StationEvents.Components;
 [RegisterComponent, Access(typeof(VentClogRule))]
 public sealed partial class VentCritterSpawnLocationComponent : Component
 {
-
+    // Vulpstation
+    [DataField] public float Weight = 1f;
 }

--- a/Content.Server/Temperature/Components/EntityHeaterComponent.cs
+++ b/Content.Server/Temperature/Components/EntityHeaterComponent.cs
@@ -12,6 +12,7 @@ public sealed partial class EntityHeaterComponent : Component
     /// <summary>
     /// Power used when heating at the high setting.
     /// Low and medium are 33% and 66% respectively.
+    /// Vulpstation - if 0, can heat even when unpowered.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float Power = 2400f;

--- a/Content.Server/_Vulp/Temperature/IntrinsicEntityHeaterComponent.cs
+++ b/Content.Server/_Vulp/Temperature/IntrinsicEntityHeaterComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._Vulp.Temperature;
+
+
+[RegisterComponent]
+public sealed partial class IntrinsicEntityHeaterComponent : Component
+{
+    [DataField]
+    public float Power = 2400;
+}

--- a/Content.Server/_Vulp/Temperature/IntrinsicEntityHeaterSystem.cs
+++ b/Content.Server/_Vulp/Temperature/IntrinsicEntityHeaterSystem.cs
@@ -1,0 +1,36 @@
+using Content.Server.Temperature.Systems;
+using Content.Shared.Examine;
+using Content.Shared.Placeable;
+
+
+namespace Content.Server._Vulp.Temperature;
+
+
+public sealed class EntityHeaterSystem : EntitySystem
+{
+    [Dependency] private readonly TemperatureSystem _temperature = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<IntrinsicEntityHeaterComponent, ExaminedEvent>(OnExamined);
+    }
+
+    public override void Update(float deltaTime)
+    {
+        var query = EntityQueryEnumerator<IntrinsicEntityHeaterComponent, ItemPlacerComponent>();
+        while (query.MoveNext(out var uid, out var heater, out var placer))
+        {
+            var energy = heater.Power * deltaTime / placer.PlacedEntities.Count;
+            foreach (var ent in placer.PlacedEntities)
+                _temperature.ChangeHeat(ent, energy);
+        }
+    }
+
+    private void OnExamined(EntityUid uid, IntrinsicEntityHeaterComponent comp, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        args.PushMarkup(Loc.GetString("entity-heater-intrinsic-examined"));
+    }
+}

--- a/Content.Shared/Storage/EntitySpawnEntry.cs
+++ b/Content.Shared/Storage/EntitySpawnEntry.cs
@@ -53,6 +53,16 @@ public partial struct EntitySpawnEntry
     [DataField] public int MaxAmount = 1;
 
     public EntitySpawnEntry() { }
+
+    // Vulpstation
+    public EntitySpawnEntry(EntitySpawnEntry copy)
+    {
+        PrototypeId = copy.PrototypeId;
+        SpawnProbability = copy.SpawnProbability;
+        GroupId = copy.GroupId;
+        Amount = copy.Amount;
+        MaxAmount = copy.MaxAmount;
+    }
 }
 
 public static class EntitySpawnCollection

--- a/Resources/Locale/en-US/_Vulp/temperature/heater.ftl
+++ b/Resources/Locale/en-US/_Vulp/temperature/heater.ftl
@@ -1,0 +1,1 @@
+entity-heater-intrinsic-examined = It looks like you could cook something on it.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 450
+  cost: 2250 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita
   product: CrateFoodPizzaLarge
-  cost: 1800
+  cost: 4000 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick
   product: CrateFoodMRE
-  cost: 1000
+  cost: 3500 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Objects/Consumable/Food/ingredients.rsi
     state: flour-big
   product: CrateFoodCooking
-  cost: 750
+  cost: 1500 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Objects/Consumable/Drinks/beerglass.rsi
     state: icon
   product: CrateFoodBarSupply
-  cost: 750
+  cost: 2250 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Objects/Consumable/Drinks/cola.rsi
     state: icon
   product: CrateFoodSoftdrinks
-  cost: 1200
+  cost: 2200 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market
 
@@ -74,6 +74,6 @@
     sprite: Objects/Consumable/Drinks/colabottle.rsi
     state: icon
   product: CrateFoodSoftdrinksLarge
-  cost: 2400
+  cost: 4000 # Vulpstation - nerfed
   category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/food.yml
@@ -2,12 +2,12 @@
   id: CrateFoodPizza
   parent: CratePlastic
   name: emergency pizza delivery
-  description: Help do your part to end station hunger by distributing pizza to underfunded departments! Includes 4 pizzas.
+  description: Help do your part to end station hunger by distributing pizza to underfunded departments! Includes 2 pizzas.
   components:
   - type: StorageFill
     contents:
     - id: FoodBoxPizzaFilled
-      amount: 4
+      amount: 2 # Vulpstation - nerfed
     - id: KnifePlastic
     - id: LidSalami
       prob: 0.01
@@ -16,14 +16,14 @@
   id: CrateFoodPizzaLarge
   parent: CratePlastic
   name: disaster pizza delivery
-  description: In the ultimate event that all else has failed, Find comfort in that more pizza solves everything. Includes 16 pizzas.
+  description: In the ultimate event that all else has failed, Find comfort in that more pizza solves everything. Includes 5 pizzas.
   components:
   - type: StorageFill
     contents:
     - id: FoodBoxPizzaFilled
-      amount: 16
+      amount: 5 # Vulpstation - nerfed
     - id: KnifePlastic
-      amount: 4
+      amount: 2 # Vulpstation - nerfed
     - id: LidSalami
       prob: 0.04
 

--- a/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
+++ b/Resources/Prototypes/Entities/Structures/Decoration/bonfire.yml
@@ -37,6 +37,13 @@
   - type: Tag
     tags:
       - NoPaint
+  - type: PlaceableSurface # Vulpstation
+  - type: ItemPlacer # Vulpstation
+    maxEntities: 4
+    whitelist:
+      components:
+      - Temperature
+  - type: IntrinsicEntityHeater # Vulpstation
 
 - type: entity
   id: Bonfire

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -4,10 +4,11 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
-    weight: 5
+    weight: 0.2 # Vulpstation - this is bad for botanists
     startDelay: 10
     duration: 120
     earliestStart: 20
+    maxOccurences: 1 # Vulpstation
   - type: CargoGiftsRule
     description: cargo-gift-pizza-small
     sender: cargo-gift-default-sender
@@ -24,10 +25,11 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: StationEvent
-      weight: 2
+      weight: 0.05 # Vulpstation - this is TERRIBLE for botanists
       startDelay: 10
       duration: 240
       earliestStart: 20
+      maxOccurences: 1 # Vulpstation
     - type: CargoGiftsRule
       description: cargo-gift-pizza-large
       sender: cargo-gift-default-sender

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -187,3 +187,18 @@
   minGroupSize: 1
   maxGroupSize: 2
   radius: 4
+
+# Vulpstation - vent critter nests.
+- type: biomeMarkerLayer
+  id: CritterSpawnLocations
+  entityMask:
+    AsteroidRock: VentEventSpawnerWeight3
+    WallRock: VentEventSpawnerWeight3
+    WallRockBasalt: VentEventSpawnerWeight3
+    WallRockChromite: VentEventSpawnerWeight3
+    WallRockSand: VentEventSpawnerWeight3
+    WallRockSnow: VentEventSpawnerWeight3
+  maxCount: 6
+  radius: 16
+  minGroupSize: 1
+  maxGroupSize: 5

--- a/Resources/Prototypes/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/Procedural/biome_ore_templates.yml
@@ -187,18 +187,3 @@
   minGroupSize: 1
   maxGroupSize: 2
   radius: 4
-
-# Vulpstation - vent critter nests.
-- type: biomeMarkerLayer
-  id: CritterSpawnLocations
-  entityMask:
-    AsteroidRock: VentEventSpawnerWeight3
-    WallRock: VentEventSpawnerWeight3
-    WallRockBasalt: VentEventSpawnerWeight3
-    WallRockChromite: VentEventSpawnerWeight3
-    WallRockSand: VentEventSpawnerWeight3
-    WallRockSnow: VentEventSpawnerWeight3
-  maxCount: 6
-  radius: 16
-  minGroupSize: 1
-  maxGroupSize: 5

--- a/Resources/Prototypes/_Vulp/Entities/Markers/vent-event-marker.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Markers/vent-event-marker.yml
@@ -1,0 +1,24 @@
+- type: entity
+  name: Vent events
+  id: VentEventSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - state: ai
+  - type: VentCritterSpawnLocation
+
+- type: entity
+  id: VentEventSpawnerWeight3
+  parent: VentEventSpawner
+  components:
+  - type: VentCritterSpawnLocation
+    weight: 3
+
+- type: entity
+  id: VentEventSpawnerWeight5
+  parent: VentEventSpawner
+  components:
+  - type: VentCritterSpawnLocation
+    weight: 5

--- a/Resources/Prototypes/_Vulp/GameRules/random-wreck.yml
+++ b/Resources/Prototypes/_Vulp/GameRules/random-wreck.yml
@@ -6,12 +6,12 @@
   - type: StationEvent
     weight: 8
     earliestStart: 30
-    reoccurrenceDelay: 45
-    maxOccurrences: 4
+    reoccurrenceDelay: 60
+    maxOccurrences: 3
     minimumPlayers: 3
     duration: 15 # This is the delay between loading wrecks & sending them to ftl, and deleting their temporary maps (possibly deleting leftover debris)
     startAnnouncement: true
   - type: RandomSalvageWreckRule
-    debrisDistanceRange: 200, 550
-    debrisOffsetRange: 0, 50
+    debrisDistanceRange: 200, 300
+    debrisOffsetRange: 0, 25
     debrisCountRange: 2, 4

--- a/Resources/Prototypes/_Vulp/Procedural/biome_templates.yml
+++ b/Resources/Prototypes/_Vulp/Procedural/biome_templates.yml
@@ -1,0 +1,20 @@
+- type: biomeMarkerLayer
+  id: CritterSpawnLocations
+  entityMask:
+    AsteroidRock: VentEventSpawnerWeight3
+    WallRock: VentEventSpawnerWeight3
+    WallRockBasalt: VentEventSpawnerWeight3
+    WallRockChromite: VentEventSpawnerWeight3
+    WallRockSand: VentEventSpawnerWeight3
+    WallRockSnow: VentEventSpawnerWeight3
+  maxCount: 6
+  radius: 16
+  minGroupSize: 1
+  maxGroupSize: 5
+
+- type: salvageLoot
+  id: CritterSpawnLocations
+  guaranteed: true
+  loots:
+  - !type:BiomeMarkerLoot
+    proto: CritterSpawnLocations


### PR DESCRIPTION
:cl:
- tweak: Food is way more expensive to purachase from cargo now. Try growing your own or ask your local botanist!
- fix: You can finally filter out subtles as you're meant to.
- feat: Bonfires can be used to cook meat similarly to a grill.
- feat: Vent critter spawners will now spawn naturally, but won't spawn anything unless there are players nearby..
- fix: Anomalies should now correctly generate planetside.