### PR TITLE
Mute Ooc Smite

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -55,6 +55,8 @@ using Timer = Robust.Shared.Timing.Timer;
 // Floof Station - For our own smites
 using Content.Server._Floof.Administration;
 using Content.Server._Floof.Administration.Components;
+using Content.Server.Mind;
+
 
 namespace Content.Server.Administration.Systems;
 
@@ -843,5 +845,26 @@ public sealed partial class AdminVerbSystem
             Impact = LogImpact.Extreme,
         };
         args.Verbs.Add(superBonk);
+
+        // Vulpstation section
+
+        if (_mindSystem.TryGetMind(args.Target, out _, out var mind))
+        {
+            var toggleOOCBan = new Verb
+            {
+                Text = mind.PreventOOC ? "Allow OOC" : "Prevent OOC",
+                Category = VerbCategory.Smite,
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/Alerts/Abilities/silenced.png")),
+                Act = () =>
+                {
+                    mind.PreventOOC = !mind.PreventOOC;
+                },
+                Impact = LogImpact.Extreme,
+                Message = "Shut the fuck up",
+            };
+            args.Verbs.Add(toggleOOCBan);
+        }
+
+        // Vulpstation section end
     }
 }

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -852,7 +852,7 @@ public sealed partial class AdminVerbSystem
         {
             var toggleOOCBan = new Verb
             {
-                Text = mind.PreventOOC ? "Allow OOC" : "Prevent OOC",
+                Text = "OOC mute toggle", // This is just here for ordering
                 Category = VerbCategory.Smite,
                 Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/Alerts/Abilities/silenced.png")),
                 Act = () =>
@@ -860,7 +860,7 @@ public sealed partial class AdminVerbSystem
                     mind.PreventOOC = !mind.PreventOOC;
                 },
                 Impact = LogImpact.Extreme,
-                Message = "Shut the fuck up",
+                Message = mind.PreventOOC ? "Allow OOC" : "Prevent OOC",
             };
             args.Verbs.Add(toggleOOCBan);
         }

--- a/Content.Server/Chat/Managers/ChatManager.cs
+++ b/Content.Server/Chat/Managers/ChatManager.cs
@@ -12,6 +12,7 @@ using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Mind;
+using Content.Shared.Players;
 using Content.Shared.Players.RateLimiting;
 using Robust.Shared.Configuration;
 using Robust.Shared.Network;
@@ -206,6 +207,10 @@ namespace Content.Server.Chat.Managers
         public void TrySendOOCMessage(ICommonSession player, string message, OOCChatType type)
         {
             if (HandleRateLimit(player) != RateLimitStatus.Allowed)
+                return;
+
+            // Vulpstation
+            if (player.GetMind() is {} mind && _entityManager.TryGetComponent<MindComponent>(mind, out var mindc) && mindc.PreventOOC)
                 return;
 
             // Check if message exceeds the character limit

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -46,6 +46,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Dynamics.Joints;
 using Content.Server.Effects;
 using Content.Server.Hands.Systems;
+using Content.Shared.Mind;
 using Content.Shared.Popups;
 
 
@@ -383,6 +384,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         // It doesn't make any sense for a non-player to send in-game OOC messages, whereas non-players may be sending
         // in-game IC messages.
         if (player?.AttachedEntity is not { Valid: true } entity || source != entity)
+            return;
+
+        // Vulpstation
+        if (player.GetMind() is {} mind && TryComp<MindComponent>(mind, out var mindc) && mindc.PreventOOC)
             return;
 
         message = SanitizeInGameOOCMessage(message);

--- a/Content.Shared/Mind/MindComponent.cs
+++ b/Content.Shared/Mind/MindComponent.cs
@@ -99,6 +99,13 @@ namespace Content.Shared.Mind
         public bool PreventSuicide { get; set; }
 
         /// <summary>
+        ///     Vulpstation - prevents the user from sending OOC messages.
+        /// </summary>
+        [ViewVariables(VVAccess.ReadWrite)]
+        [DataField("preventOOC")]
+        public bool PreventOOC { get; set; }
+
+        /// <summary>
         ///     The session of the player owning this mind.
         ///     Can be null, in which case the player is currently not logged in.
         /// </summary>


### PR DESCRIPTION
# Description
For noisy raiders who like to scream in ooc while getting admin-abused.

<details><summary><h1>Media</h1></summary><p>


https://github.com/user-attachments/assets/08f67796-9836-4f8f-9d2a-d079cd873e3c


</p></details>

# Changelog
:cl:
- feat: Admins can now OOC-mute particular players, so raiders should be less of a nuisance now.
