### PR TITLE
Planet QOL Improvements

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -363,11 +363,11 @@ namespace Content.Server.Atmos.EntitySystems
                 if (heatCapacity > Atmospherics.MinimumHeatCapacity)
                 {
                     var atmosHeatCapacity = GetHeatCapacity(mapAtmos.Mixture);
-                    var heat = heatCapacity * tempDiff;
-                    var atmosHeat = atmosHeatCapacity * tempDiff;
+                    var heat = heatCapacity * tile.Air.Temperature;
+                    var atmosHeat = atmosHeatCapacity * mapAtmos.Mixture.Temperature;
                     heatDiff = atmosHeat - heat;
 
-                    tile.Air.Temperature -= heat / heatCapacity * Atmospherics.OpenHeatTransferCoefficient * (1f / tile.RegenerateAtmos);
+                    tile.Air.Temperature += heatDiff / heatCapacity * Atmospherics.OpenHeatTransferCoefficient * (1f / tile.RegenerateAtmos);
                     tile.Temperature = tile.TemperatureArchived = tile.Air.Temperature;
                 }
             }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Processing.cs
@@ -191,6 +191,10 @@ namespace Content.Server.Atmos.EntitySystems
                 tile.ThermalConductivity = contentDef.ThermalConductivity;
                 tile.HeatCapacity = contentDef.HeatCapacity;
                 tile.NoGridTile = false;
+                // Vulpstation
+                tile.RegenerateAtmos = _tileDefinitionManager.TryGetDefinition(gTile.TypeId, out var def) && def is ContentTileDefinition cdef
+                    ? cdef.RegenerateAtmos
+                    : 0;
             }
             else
             {

--- a/Content.Server/Atmos/TileAtmosphere.cs
+++ b/Content.Server/Atmos/TileAtmosphere.cs
@@ -116,6 +116,12 @@ namespace Content.Server.Atmos
         public bool MapAtmosphere;
 
         /// <summary>
+        /// Vulpstation change. <seealso cref="ITileDefinition.RegenerateAtmos"/>
+        /// </summary>
+        [ViewVariables]
+        public int RegenerateAtmos;
+
+        /// <summary>
         /// If true, this tile does not actually exist on the grid, it only exists to represent the map's atmosphere for
         /// adjacent grid tiles.
         /// </summary>

--- a/Content.Server/_Vulp/Tiles/TileSpreadComponent.cs
+++ b/Content.Server/_Vulp/Tiles/TileSpreadComponent.cs
@@ -49,4 +49,17 @@ public sealed partial class TileSpreadInfo
     /// </summary>
     [DataField]
     public float Probability = 0.01f;
+
+    /// <summary>
+    /// If true, the tiles listed in <see cref="SpreadsTo"/> will revert to <see cref="ID"/> when they are covered by a wall.
+    /// </summary>
+    [DataField]
+    public bool DieUnderWalls = false;
+
+    /// <summary>
+    /// If <see cref="DieUnderWalls"/> is true, this is the probability that a tile will die when a wall is placed over it.
+    /// </summary>
+    [DataField]
+    public float DeathProbability = 0.1f;
+
 }

--- a/Content.Server/_Vulp/Tiles/TileSpreadSystem.cs
+++ b/Content.Server/_Vulp/Tiles/TileSpreadSystem.cs
@@ -44,7 +44,21 @@ public sealed class TileSpreadSystem : EntitySystem
             {
                 // don't spread under walls
                 if (_map.GetAnchoredEntities(new(uid, mapGrid), tile.GridIndices).Any(HasComp<AirtightComponent>))
+                {
+                    var tileType = _tileDefs[tile.Tile.TypeId].ID;
+                    var def = tileSpread.Tiles.FirstOrDefault(it => it.ID == tileType);
+                    if (def == null || !def.DieUnderWalls || def.SpreadsTo.Length == 0)
+                        continue;
+
+                    // Revert the tile back to a random base tile
+                    if (!_random.Prob(def.Probability))
+                        continue;
+
+                    var baseTile = _random.Pick(def.SpreadsTo);
+                    _map.SetTile(uid, mapGrid, tile.GridIndices, new(_tileDefs[baseTile].TileId));
+
                     continue;
+                }
 
                 var chosenTile = tileSpread.Tiles
                     .Where(info => info.SpreadsTo.Contains(_tileDefs[tile.Tile.TypeId].ID))

--- a/Content.Server/_Vulp/Tiles/TileSpreadSystem.cs
+++ b/Content.Server/_Vulp/Tiles/TileSpreadSystem.cs
@@ -43,7 +43,7 @@ public sealed class TileSpreadSystem : EntitySystem
             foreach (var tile in _map.GetAllTiles(uid, mapGrid))
             {
                 // don't spread under walls
-                if (_map.GetAnchoredEntities(new(uid, mapGrid), tile.GridIndices).Any(HasComp<AirtightComponent>))
+                if (_map.GetAnchoredEntities((uid, mapGrid), tile.GridIndices).Any(HasComp<AirtightComponent>))
                 {
                     var tileType = _tileDefs[tile.Tile.TypeId].ID;
                     var def = tileSpread.Tiles.FirstOrDefault(it => it.ID == tileType);
@@ -56,7 +56,6 @@ public sealed class TileSpreadSystem : EntitySystem
 
                     var baseTile = _random.Pick(def.SpreadsTo);
                     _map.SetTile(uid, mapGrid, tile.GridIndices, new(_tileDefs[baseTile].TileId));
-
                     continue;
                 }
 

--- a/Content.Shared/Maps/ContentTileDefinition.cs
+++ b/Content.Shared/Maps/ContentTileDefinition.cs
@@ -69,6 +69,14 @@ namespace Content.Shared.Maps
         [DataField("variants")] public byte Variants { get; set; } = 1;
 
         /// <summary>
+        ///     Vulpstation - speed at which this tile regenerates the air of the MapAtmosphere on its tile of the GridAtmosphere.
+        ///     This one is hard to explain, but if it's 0, then the tile doesn't regenerate.
+        ///     The greater the value is compared to 0, the SLOWER it regenerates.
+        ///     A value of 1 means it will regenerate almost instantly. A value of 100 will be quite slow.
+        /// </summary>
+        [DataField] public int RegenerateAtmos { get; set; } = 0;
+
+        /// <summary>
         /// This controls what variants the `variantize` command is allowed to use.
         /// </summary>
         [DataField("placementVariants")] public float[] PlacementVariants { get; set; } = { 1f };

--- a/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
+++ b/Resources/Prototypes/Entities/Tiles/liquid_plasma.yml
@@ -2,6 +2,7 @@
   id: FloorLiquidPlasmaEntity
   name: liquid plasma
   description: Sweet, expensive nectar. Don't consume.
+  parent: FloorWaterEntity # Vulp
   placement:
     mode: SnapgridCenter
     snap:
@@ -55,3 +56,15 @@
   - type: Tag
     tags:
     - HideContextMenu
+  # Vulpstation section
+  - type: SolutionContainerManager
+    solutions:
+      pool:
+        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable.
+        reagents:
+        - ReagentId: Plasma
+          Quantity: 9999999
+      drainBuffer: # Vulp - to collect waste
+        maxVol: 9999999
+        reagents: []
+  # Vulpstation section end

--- a/Resources/Prototypes/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/Entities/Tiles/water.yml
@@ -20,18 +20,17 @@
   - type: SolutionContainerManager
     solutions:
       pool:
-        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable. 
+        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable.
         reagents:
         - ReagentId: Water
           Quantity: 9999999
-  - type: SolutionRegeneration
-    solution: tank
-    generated:
-      reagents:
-      - ReagentId: Water
-        Quantity: 100
+      drainBuffer: # Vulp
+        maxVol: 9999999
   - type: DrainableSolution
-    solution: pool
+    solution: pool # Vulp
+  - type: DumpableSolution # Vulp
+    solution: drainBuffer
+  - type: Drain # Vulp
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5

--- a/Resources/Prototypes/Entities/Tiles/water.yml
+++ b/Resources/Prototypes/Entities/Tiles/water.yml
@@ -31,6 +31,7 @@
   - type: DumpableSolution # Vulp
     solution: drainBuffer
   - type: Drain # Vulp
+    autoDrain: false # It would be nice, BUT it's a major performance burder. Better make rain erase puddles or something.
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5

--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -12,6 +12,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Desert
 - type: tile
@@ -32,6 +33,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 - type: tile
   id: FloorLowDesert
@@ -51,6 +53,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Vulp: use indestructible sand on planets
 - type: tile
@@ -78,6 +81,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Grass
 - type: tile
@@ -109,6 +113,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: false # Vulp
+  regenerateAtmos: 8 # Vulp. Grass is a bit better.
 
 # Lava
 - type: tile
@@ -121,6 +126,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Snow
 - type: tile
@@ -156,6 +162,7 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Ice
 - type: tile
@@ -170,6 +177,7 @@
   mobFrictionNoInput: 0.05
   mobAcceleration: 2
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Dug snow
 - type: tile
@@ -188,5 +196,6 @@
   heatCapacity: 10000
   weather: true
   indestructible: true
+  regenerateAtmos: 10 # Vulp
 
 # Wasteland

--- a/Resources/Prototypes/_Nuclear14/Tiles/water.yml
+++ b/Resources/Prototypes/_Nuclear14/Tiles/water.yml
@@ -2,6 +2,7 @@
   id: N14FloorWaterDirtyEntity
   name: water
   description: A real thirst quencher.
+  parent: FloorWaterEntity # Vulp
   placement:
     mode: SnapgridCenter
     snap:
@@ -17,15 +18,16 @@
     drawdepth: BelowFloor
     layers:
       - state: shoreline_water
-  - type: SolutionContainerManager
-    solutions:
-      pool:
-        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable.
-        reagents:
-        - ReagentId: Water
-          Quantity: 9999999
-  - type: DrainableSolution
-    solution: pool
+# Vulp - don't uncomment.
+#  - type: SolutionContainerManager
+#    solutions:
+#      pool:
+#        maxVol: 9999999 #.inf seems to break the whole yaml file, but would definitely be preferable.
+#        reagents:
+#        - ReagentId: Water
+#          Quantity: 9999999
+#  - type: DrainableSolution
+#    solution: pool
   - type: SpeedModifierContacts
     walkSpeedModifier: 0.5
     sprintSpeedModifier: 0.5
@@ -148,6 +150,8 @@
         reagents:
         - ReagentId: Water #TODO: Add WaterSalt Reagent.
           Quantity: 9999999
+      drain: # Vulp
+        maxVol: 9999999
 
 - type: entity
   parent: N14FloorWaterSaltDeep

--- a/Resources/Prototypes/_Vulp/Maps/planet-bouba.yml
+++ b/Resources/Prototypes/_Vulp/Maps/planet-bouba.yml
@@ -21,6 +21,7 @@
           tiles:
           - id: FloorPlanetGrass
             spreadsTo: [ FloorPlanetDirt ]
+            dieUnderWalls: true
       - type: StationJobs
         overflowJobs:
         - Passenger

--- a/Resources/Prototypes/_Vulp/Maps/planet-colony-drop-pod.yml
+++ b/Resources/Prototypes/_Vulp/Maps/planet-colony-drop-pod.yml
@@ -36,6 +36,7 @@
           tiles:
           - id: FloorPlanetGrass
             spreadsTo: [ FloorPlanetDirt ]
+            dieUnderWalls: true
       - type: StationJobs
         overflowJobs:
         - Passenger


### PR DESCRIPTION
# Description
Makes grass die under walls, adds DumpableSolution and Drain to rivers, changes the atmos system to allow certain tiles to regenerate the local MapAtmosphere...


https://github.com/user-attachments/assets/7870cc7c-b073-45d6-84d9-2797d5b16452



# Changelog
:cl:
- add: Grass tiles (and other spreading tiles) can now "die" and revert back to dirt when covered by a wall. It takes time, though.
- add: You can now dump liquids into rivers.
- tweak: You can now collect liquid plasma from plasma rivers.
- feat: Planetary tiles (such as grass, dirt, snow, etc) now slowly regenerate the planet's atmosphere. This includes removing excess/unnecessary gasses, adding missing, and stabilizing temperature.
