### PR TITLE
Major Fixes

### DIFF
--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -30,8 +30,10 @@ public sealed class FloorOcclusionSystem : SharedFloorOcclusionSystem
 
     protected override void SetEnabled(EntityUid uid, FloorOcclusionComponent component, bool enabled)
     {
-        if (component.Enabled == enabled)
-            return;
+        // Vulpstation - don't do this. Client has prediction and it can interfere.
+        // E.g. if the server sets this field to false, the client might not remove the shader
+        // if (component.Enabled == enabled)
+        //     return;
 
         base.SetEnabled(uid, component, enabled);
 

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.LINDA.cs
@@ -351,6 +351,8 @@ namespace Content.Server.Atmos.EntitySystems
                 mapAtmos.Mixture,
                 true);
 
+            atmosSharer.Temperature = atmosSharer.TemperatureArchived = atmosSharer.Air!.Temperature;
+            tile.TemperatureArchived = tile.Temperature = tile.Air!.Temperature; // For some reason it isn't set by the system
             var pressureDiff = Share(tile, atmosSharer, tile.RegenerateAtmos);
 
             // Slow and gradual temperature change

--- a/Content.Server/GameTicking/Rules/Components/SecretRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/SecretRuleComponent.cs
@@ -1,4 +1,8 @@
-﻿namespace Content.Server.GameTicking.Rules.Components;
+﻿using Content.Shared.Random;
+using Robust.Shared.Prototypes;
+
+
+namespace Content.Server.GameTicking.Rules.Components;
 
 [RegisterComponent, Access(typeof(SecretRuleSystem))]
 public sealed partial class SecretRuleComponent : Component
@@ -8,4 +12,8 @@ public sealed partial class SecretRuleComponent : Component
     /// </summary>
     [DataField("additionalGameRules")]
     public HashSet<EntityUid> AdditionalGameRules = new();
+
+    // Vulpstation
+    [DataField("pool")]
+    public ProtoId<WeightedRandomPrototype> Pool = "SecretBasic";
 }

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -35,7 +35,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     protected override void Added(EntityUid uid, SecretRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
         base.Added(uid, component, gameRule, args);
-        var weights = _configurationManager.GetCVar(CCVars.SecretWeightPrototype);
+        var weights = component.Pool; // Vulpstation
 
         if (!TryPickPreset(weights, out var preset))
         {

--- a/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
+++ b/Content.Server/NPC/Systems/NPCSteeringSystem.Context.cs
@@ -158,6 +158,13 @@ public sealed partial class NPCSteeringSystem
             }
         }
 
+        // Vulpstation - if target is null, just don't do shit. This keeps throwing errors.
+        if (!targetCoordinates.IsValid(EntityManager))
+        {
+            steering.Status = SteeringStatus.NoPath;
+            return false;
+        }
+
         // Check if mapids match.
         var targetMap = targetCoordinates.ToMap(EntityManager, _transform);
         var ourMap = ourCoordinates.ToMap(EntityManager, _transform);

--- a/Content.Server/Parallax/BiomeSystem.UnloadingChecks.cs
+++ b/Content.Server/Parallax/BiomeSystem.UnloadingChecks.cs
@@ -25,12 +25,11 @@ public sealed partial class BiomeSystem
             return;
 
         var uid = ent.Owner;
-        if (EntityManager.ComponentCount(uid) > 20)
-            args.Unload = false; // Just fuck saving that
-        else if (HasComp<ContainerManagerComponent>(uid))
-            args.Unload = false; // Yeah no that'd require map serilization at least
-        else if (HasComp<ItemSlotsComponent>(uid))
+        if (HasComp<ContainerManagerComponent>(uid) || HasComp<ItemSlotsComponent>(uid))
+        {
             args.Unload = false;
+            args.MarkTileModified |= !args.Unload;
+        }
     }
 
     private void OnMobUnloading(Entity<MobStateComponent> ent, ref BiomeUnloadingEvent args)
@@ -51,6 +50,7 @@ public sealed partial class BiomeSystem
     private void OnPuddleUnloading(Entity<PuddleComponent> ent, ref BiomeUnloadingEvent args)
     {
         // Fuck puddles, man
+        args.Unload = false;
         args.Delete = true;
     }
 }

--- a/Content.Server/Parallax/BiomeSystem.UnloadingChecks.cs
+++ b/Content.Server/Parallax/BiomeSystem.UnloadingChecks.cs
@@ -1,0 +1,76 @@
+using Content.Shared.Construction.Components;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Containers;
+
+
+namespace Content.Server.Parallax;
+
+// This file is part of floofstation changes
+public sealed partial class BiomeSystem
+{
+    private void InitializeUnloadingChecks()
+    {
+        SubscribeLocalEvent<BiomeUnloadingEvent>(BaseUnloadingChecks);
+        SubscribeLocalEvent<MobStateComponent, BiomeUnloadingEvent>(OnMobUnloading);
+        SubscribeLocalEvent<AnchorableComponent, BiomeUnloadingEvent>(OnAnchorableUnloading);
+    }
+
+    private void BaseUnloadingChecks(EntityUid uid, BiomeUnloadingEvent args)
+    {
+        var savable = true;
+        if (EntityManager.ComponentCount(uid) > 20)
+            savable = false; // Just fuck saving that
+        else if (HasComp<ContainerManagerComponent>(uid))
+            savable = false; // Yeah no that'd require map serilization at least
+        else if (HasComp<ItemSlotsComponent>(uid))
+            savable = false;
+
+        args.Unload = args.Unload && savable;
+        // Anchorable entities will be set to have their tile marked as modified below
+        // Unanchored entities and items can be just left on the ground
+    }
+
+    private void OnMobUnloading(Entity<MobStateComponent> ent, ref BiomeUnloadingEvent args)
+    {
+        // Alive mobs just gen unloaded and then brought back
+        // Dead mobs are deleted completely
+        var isAlive = ent.Comp.CurrentState is MobState.Alive;
+        args.Unload = isAlive;
+        args.Delete = !isAlive;
+    }
+
+    private void OnAnchorableUnloading(Entity<AnchorableComponent> ent, ref BiomeUnloadingEvent args)
+    {
+        args.Unload = args.IsSameTile && Transform(ent).Anchored;
+        args.MarkTileModified = !args.IsSameTile;
+    }
+}
+
+// Vulpstation
+/// <summary>
+///     Raised on an entity during chunk unloading to determine if the entity needs to be unloaded, deleted, or ignored.
+///     If both fields are false, the entity will remain on the map in-between unloaded chunks.
+/// </summary>
+[ByRefEvent]
+public sealed class BiomeUnloadingEvent
+{
+    /// <summary>
+    ///     If true, the entity should be deleted and then re-generated when the chunk gets loaded back.
+    /// </summary>
+    public bool Unload = true;
+
+    /// <summary>
+    ///     If true, the entity should be deleted and forgotten about.
+    /// </summary>
+    public bool Delete = false;
+
+    /// <summary>
+    ///     If true, the tile this entity was spawned from should be marked as modified.
+    ///     This WILL conflict with Unload by preventing the entity from being spawned back.
+    /// </summary>
+    public bool MarkTileModified = false;
+
+    public bool IsSameTile;
+}

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -927,8 +927,7 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
         // We don't pool this one because pretty much every chunk will contain ores that do not need to be replaced
         var replacedEntities = component.ReplacedEntities.GetOrNew(chunk);
         var replacedTiles = component.ReplacedTiles.GetOrNew(chunk);
-        replacedEntities.Clear();
-        replacedTiles.Clear();
+        replacedTiles.Clear(); // Do NOT clear replacedEntities, it's a persistent dict
 
         // Delete decals
         foreach (var (dec, indices) in component.LoadedDecals[chunk])

--- a/Content.Server/Parallax/BiomeSystem.cs
+++ b/Content.Server/Parallax/BiomeSystem.cs
@@ -1011,13 +1011,13 @@ public sealed partial class BiomeSystem : SharedBiomeSystem
                     ev.IsSameTile = false;
                     RaiseLocalEvent(ent.Value, ref ev);
 
+                    // This is guaranteed to not be a naturally generated entity, so MarkTileModified is ignored unless both delete and unload are false
                     if (ev.Delete || ev.Unload)
                     {
                         replacedEntities[indices] = ev.Delete ? null : MetaData(ent.Value).EntityPrototype?.ID;
                         Del(ent.Value);
                     }
-
-                    if (ev.MarkTileModified)
+                    else if (ev.MarkTileModified)
                     {
                         modified.Add(indices);
                         continue;

--- a/Content.Shared/Atmos/GasMixture.cs
+++ b/Content.Shared/Atmos/GasMixture.cs
@@ -319,7 +319,7 @@ namespace Content.Shared.Atmos
 
             for (var i = 0; i < Atmospherics.AdjustedNumberOfGases; i++)
             {
-                if (Math.Abs(Moles[i] - other.Moles[i]) > 0.5f)
+                if (Math.Abs(Moles[i] - other.Moles[i]) > 2f)
                     return false;
             }
 

--- a/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
@@ -22,8 +22,6 @@ public abstract class SharedFloorOcclusionSystem : EntitySystem
 
     private void OnStartCollide(EntityUid uid, FloorOccluderComponent component, ref StartCollideEvent args)
     {
-        if (!_timing.IsFirstTimePredicted) // Vulp
-            return;
         var other = args.OtherEntity;
 
         if (!TryComp<FloorOcclusionComponent>(other, out var occlusion) ||
@@ -38,8 +36,6 @@ public abstract class SharedFloorOcclusionSystem : EntitySystem
 
     private void OnEndCollide(EntityUid uid, FloorOccluderComponent component, ref EndCollideEvent args)
     {
-        if (!_timing.IsFirstTimePredicted) // Vulp
-            return;
         var other = args.OtherEntity;
 
         if (!TryComp<FloorOcclusionComponent>(other, out var occlusion))

--- a/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedFloorOcclusionSystem.cs
@@ -1,13 +1,18 @@
 using Content.Shared.Movement.Components;
 using Robust.Shared.Physics.Events;
+using Robust.Shared.Timing;
+
 
 namespace Content.Shared.Movement.Systems;
+
 
 /// <summary>
 /// Applies an occlusion shader for any relevant entities.
 /// </summary>
 public abstract class SharedFloorOcclusionSystem : EntitySystem
 {
+    [Dependency] private readonly IGameTiming _timing = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -17,6 +22,8 @@ public abstract class SharedFloorOcclusionSystem : EntitySystem
 
     private void OnStartCollide(EntityUid uid, FloorOccluderComponent component, ref StartCollideEvent args)
     {
+        if (!_timing.IsFirstTimePredicted) // Vulp
+            return;
         var other = args.OtherEntity;
 
         if (!TryComp<FloorOcclusionComponent>(other, out var occlusion) ||
@@ -31,6 +38,8 @@ public abstract class SharedFloorOcclusionSystem : EntitySystem
 
     private void OnEndCollide(EntityUid uid, FloorOccluderComponent component, ref EndCollideEvent args)
     {
+        if (!_timing.IsFirstTimePredicted) // Vulp
+            return;
         var other = args.OtherEntity;
 
         if (!TryComp<FloorOcclusionComponent>(other, out var occlusion))

--- a/Content.Shared/Parallax/Biomes/BiomeComponent.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeComponent.cs
@@ -62,6 +62,12 @@ public sealed partial class BiomeComponent : Component
     public Dictionary<Vector2i, Dictionary<EntityUid, Vector2i>> LoadedEntities = new();
 
     /// <summary>
+    /// Vulpstation - what entities should spawn at these locations instead of the default? if null, then nothing
+    /// </summary>
+    [DataField]
+    public Dictionary<Vector2i, Dictionary<Vector2i, string?>> RepalcedEntities = new();
+
+    /// <summary>
     /// Currently active chunks
     /// </summary>
     [DataField("loadedChunks")]

--- a/Content.Shared/Parallax/Biomes/BiomeComponent.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeComponent.cs
@@ -69,6 +69,12 @@ public sealed partial class BiomeComponent : Component
     public Dictionary<Vector2i, Dictionary<Vector2i, string?>> ReplacedEntities = new();
 
     /// <summary>
+    /// Vulpstation - all entities that couldn't be unloaded but were paused instead.
+    /// </summary>
+    [DataField]
+    public Dictionary<Vector2i, HashSet<EntityUid>> PausedEntities = new();
+
+    /// <summary>
     /// Vulpstation - what tiles in this chunk are different from the default.
     /// </summary>
     [DataField]

--- a/Content.Shared/Parallax/Biomes/BiomeComponent.cs
+++ b/Content.Shared/Parallax/Biomes/BiomeComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Parallax.Biomes.Layers;
 using Content.Shared.Parallax.Biomes.Markers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Noise;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
@@ -65,7 +66,13 @@ public sealed partial class BiomeComponent : Component
     /// Vulpstation - what entities should spawn at these locations instead of the default? if null, then nothing
     /// </summary>
     [DataField]
-    public Dictionary<Vector2i, Dictionary<Vector2i, string?>> RepalcedEntities = new();
+    public Dictionary<Vector2i, Dictionary<Vector2i, string?>> ReplacedEntities = new();
+
+    /// <summary>
+    /// Vulpstation - what tiles in this chunk are different from the default.
+    /// </summary>
+    [DataField]
+    public Dictionary<Vector2i, Dictionary<Vector2i, Tile>> ReplacedTiles = new();
 
     /// <summary>
     /// Currently active chunks

--- a/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
+++ b/Content.Shared/Parallax/Biomes/SharedBiomeSystem.cs
@@ -331,11 +331,16 @@ public abstract class SharedBiomeSystem : EntitySystem
 
     private FastNoiseLite GetNoise(FastNoiseLite seedNoise, int seed)
     {
-        var noiseCopy = new FastNoiseLite();
-        _serManager.CopyTo(seedNoise, ref noiseCopy, notNullableOverride: true);
-        noiseCopy.SetSeed(noiseCopy.GetSeed() + seed);
-        // Ensure re-calculate is run.
-        noiseCopy.SetFractalOctaves(noiseCopy.GetFractalOctaves());
-        return noiseCopy;
+        // var noiseCopy = new FastNoiseLite();
+        // _serManager.CopyTo(seedNoise, ref noiseCopy, notNullableOverride: true);
+        // noiseCopy.SetSeed(noiseCopy.GetSeed() + seed);
+        // // Ensure re-calculate is run.
+        // noiseCopy.SetFractalOctaves(noiseCopy.GetFractalOctaves());
+        // return noiseCopy;
+
+        // Vulpstation - what the FUCK is the above?!
+        seedNoise.SetSeed(seed);
+        seedNoise.SetFractalOctaves(seedNoise.GetFractalOctaves());
+        return seedNoise;
     }
 }

--- a/Content.Shared/Standing/StandingStateSystem.cs
+++ b/Content.Shared/Standing/StandingStateSystem.cs
@@ -85,6 +85,8 @@ public sealed class StandingStateSystem : EntitySystem
                 _physics.SetCollisionMask(uid, key, fixture, fixture.CollisionMask & ~StandingCollisionLayer, manager: fixtureComponent);
             }
 
+        _movement.RefreshMovementSpeedModifiers(uid); // Vulpstation - moved this up because it's just necessary to invoke.
+
         // check if component was just added or streamed to client
         // if true, no need to play sound - mob was down before player could seen that
         if (standingState.LifeStage <= ComponentLifeStage.Starting)
@@ -92,8 +94,6 @@ public sealed class StandingStateSystem : EntitySystem
 
         if (playSound)
             _audio.PlayPredicted(standingState.DownSound, uid, null);
-
-        _movement.RefreshMovementSpeedModifiers(uid);
 
         Climb(uid);
 

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-secret.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-secret.ftl
@@ -1,2 +1,6 @@
-secret-title = Secret
+secret-title = Secret (normal)
 secret-description = It's a secret to everyone. The threats you encounter are randomized.
+
+# Vulpstation
+secret-hellish-title = Secret (hellish)
+secret-hellish-description = It's a secret to everyone. The threats you encounter are randomized but likely to be more extreme.

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -29,6 +29,7 @@
   - Security
   - Maintenance
   - External
+  - Orders # Vulpstation
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -45,6 +45,8 @@
     - NuclearOperative
     - SyndicateAgent
     - CentralCommand
+    - DV-SpareSafe
+    - Freelancer
   - type: UserInterface
     interfaces:
       enum.SolarControlConsoleUiKey.Key:

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -227,6 +227,15 @@
   components:
   - type: SecretRule
 
+# Vulpstation
+- type: entity
+  id: SecretHellish
+  parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SecretRule
+    pool: SecretHellish
+
 - type: entity
   id: Zombie
   parent: BaseGameRule
@@ -307,7 +316,7 @@
     startingSlope: -1
     downwardsLimit: -0.4
     upwardsLimit: 0.3
-    
+
 # variation passes
 - type: entity
   id: BasicRoundstartVariation

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -12,6 +12,7 @@
   - AllAccess
   access:
   - CentralCommand
+  - DV-SpareSafe
 
 - type: startingGear
   id: CentcomGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -40,6 +40,7 @@
 #  - Brig
   - Lawyer
   - Cargo
+  - Orders # Vulpstation
 #  - Atmospherics
 #  - Medical
   - Boxer # DeltaV - Add Boxer access

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -23,6 +23,7 @@
   - ChiefEngineer
   - Atmospherics
   - Cryogenics
+  - Orders # Vulpstation
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -26,6 +26,7 @@
   - External # DeltaV - Paramedics need this access
   - Psychologist # DeltaV - Add Psychologist access
   - Cryogenics
+  - Orders # Vulpstation
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -31,6 +31,7 @@
   - Mantis # DeltaV - Mantis, see Resources/Prototypes/DeltaV/Access/epistemics.yml
   - Chapel # DeltaV - Chaplain is in Epistemics
   - Cryogenics
+  - Orders # Vulpstation
   special: # Nyanotrasen - Mystagogue can use the Bible
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -28,6 +28,7 @@
   - Detective
   - Corpsman # DeltaV - added Corpsman access
   - Cryogenics
+  - Orders # Vulpstation
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -32,6 +32,7 @@
   - Command
   - CentralCommand
   - BlueshieldOfficer
+  - Orders # Vulpstation
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Vulp/Entities/Stations/planet.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Stations/planet.yml
@@ -14,6 +14,8 @@
   - BaseStationAllEventsEligible
   - BaseStationExpeditions
   - BaseStationTheDark
+  - BaseStationCaptainState # DeltaV
+  - BaseStationStockMarket # DeltaV
   categories: [ HideSpawnMenu ]
   components:
   - type: Transform

--- a/Resources/Prototypes/_Vulp/Procedural/biome_loot.yml
+++ b/Resources/Prototypes/_Vulp/Procedural/biome_loot.yml
@@ -5,9 +5,10 @@
   - !type:BiomeMarkerLoot
     proto: CritterSpawnLocations
 
-- type: salvageLoot
-  id: Lizards
-  guaranteed: true
-  loots:
-  - !type:BiomeMarkerLoot
-    proto: Lizards
+# Causes performance issues, so commenting them out for now. We need to make the biome system archive entities on unloaded chunks.
+#- type: salvageLoot
+#  id: Lizards
+#  guaranteed: true
+#  loots:
+#  - !type:BiomeMarkerLoot
+#    proto: Lizards

--- a/Resources/Prototypes/_Vulp/Procedural/biome_loot.yml
+++ b/Resources/Prototypes/_Vulp/Procedural/biome_loot.yml
@@ -6,9 +6,9 @@
     proto: CritterSpawnLocations
 
 # Causes performance issues, so commenting them out for now. We need to make the biome system archive entities on unloaded chunks.
-#- type: salvageLoot
-#  id: Lizards
-#  guaranteed: true
-#  loots:
-#  - !type:BiomeMarkerLoot
-#    proto: Lizards
+- type: salvageLoot
+  id: Lizards
+  guaranteed: true
+  loots:
+  - !type:BiomeMarkerLoot
+    proto: Lizards

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -91,6 +91,15 @@
   rules:
     - Secret
 
+# Vulpstation
+- type: gamePreset
+  id: SecretHellish
+  name: secret-hellish-title
+  showInVote: true
+  description: secret-hellish-description
+  rules:
+    - SecretHellish
+
 - type: gamePreset
   id: SecretExtended #For Admin Use: Runs Extended but shows "Secret" in lobby.
   alias:

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,10 +1,10 @@
 - type: weightedRandom
-  id: Secret
+  id: SecretBasic
   weights:
-    Survival: 0.18
+    #Survival: 0.18
     #SurvivalHellshift: 0.20
-    SurvivalIrregular: 0.18
-    SurvivalIrregularExtended: 0.18
+    SurvivalIrregular: 0.5
+    SurvivalIrregularExtended: 0.15
     #AllAtOnce: 0.20
     #Nukeops: 0.15
     #Zombie: 0.03
@@ -13,4 +13,16 @@
     Traitor: 0.46
     #Pirates: 0.15 #ahoy me bucko
     #BloodCult: 0.05 # Floofstation - removed
+
+# Vulpstation
+- type: weightedRandom
+  id: SecretHellish
+  weights:
+    SurvivalIrregular: 3
+    Survival: 3 # Survival on its own is hellish
+    Nukeops: 0.5 # Lets see how this plays out
+    Zombie: 1
+    Revolutionary: 0.5
+    Traitor: 3
+    BloodCult: 0.5 # I don't know how this one will work.
 


### PR DESCRIPTION
# Description
See CL, testing is needed for the atmos part and floor occlusion parts

# Changelog
:cl:
- fix: Entities should no longer get stuck in the "in-water" state after touching a river tile.
- fix: Stock trading and automatic AA cabinet unlocking should work as expected now.
- tweak: During chunk unloading, significantly more entities will be temporarily deleted. This should improve server performance. This includes NPCs - they won't be able to just wander off into the void and then appear inside a wall anymore!
- fix: Admin ghosts and centcom officials now have access to the spare ID cabinet.
- tweak: All command roles now have roundstart Orders access. No need to break into the spare ID cabinet for it.
- tweak: The secret gamemode can no longer roll survival. However, there's now a separate gamemode that can roll it and more.