### PR TITLE
Improved Starting Pod and More

### DIFF
--- a/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.Shuttle.cs
@@ -317,6 +317,10 @@ public sealed partial class DockingSystem
            // If it's a map check no hard collidable anchored entities overlap
            if (isMap)
            {
+               // Vulpstation - just flatten whatever is there. The problem is planet grids often contain a lot of hard entities,
+               // and if there's no valid spawns, the shuttle is just gonna FTL to (0, 0) and flatten everything there anyway.
+               // A better solution is to cancel FTL if there's no valid docks, but that's for later.
+               return true;
                foreach (var tile in grid.GetLocalTilesIntersecting(aabb))
                {
                    var anchoredEnumerator = grid.GetAnchoredEntitiesEnumerator(tile.GridIndices);

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -91,6 +91,20 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
             args.Station);
 
         _random.Shuffle(possibleContainers);
+        // Vulpstation - sort the spawners so that job-specific spawners are preferred
+        possibleContainers.Sort(
+            (a, b) =>
+            {
+                if (a.Comp1.Job == b.Comp1.Job)
+                    return 0;
+                if (a.Comp1.Job == null)
+                    return 1;
+                if (b.Comp1.Job == null)
+                    return -1;
+
+                return 0;
+            });
+
         foreach (var (uid, spawnPoint, manager, xform) in possibleContainers)
         {
             if (!_container.TryGetContainer(uid, spawnPoint.ContainerId, out var container, manager))

--- a/Content.Server/_Vulp/Station/Components/PlanetStationComponent.cs
+++ b/Content.Server/_Vulp/Station/Components/PlanetStationComponent.cs
@@ -22,10 +22,16 @@ public sealed partial class PlanetStationComponent : Component
     public bool SpawnLoot = true;
 
     /// Components to add to the map post-planetization.
+    /// TODO: see if adding [AlwaysPushInheritance] allows to offload some components to parent prototypes
     [DataField(required: true)]
     public ComponentRegistry Components = default!;
 
+    /// If true, the station grid will be irreversibly merged into the planet upon spawning.
+    /// This is incompatible with FTL.
+    [DataField]
+    public bool MergeIntoPlanet = false;
+
     /// Time range between the spawn of the station and its arrival on the planet, in seconds. If null, skips FTL.
     [DataField]
-    public MinMax? FtlTime = null; // new(60, 90); // TODO: broken - doesn't allow ContainerFills to run properly (only happens in prod, can't debug)
+    public MinMax? FtlTime = null;
 }

--- a/Resources/Maps/_Vulp/StartingShuttles/colony-drop-pod.yml
+++ b/Resources/Maps/_Vulp/StartingShuttles/colony-drop-pod.yml
@@ -28,7 +28,7 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: AAAAAAAA/gAAAAAA/gAAAAAALQAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAA2AAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAALQAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAALQAAAAAA/gAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAALQAAAAAA/gAAAAAALQAAAAAALQAAAAAAzgAAAAAAzgAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAzgAAAAAAzgAAAAAAzgAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAzgAAAAAAzgAAAAAAzgAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAswAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAwQAAAAAAwgAAAAAA/gAAAAAAwQAAAAAA/gAAAAAAswAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAwQAAAAAA/gAAAAAAswAAAAAA/gAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAwQAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAswAAAAAA/gAAAAAA/gAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAoAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAoAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAoAAAAAAAswAAAAAAoAAAAAAA/gAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAAoAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAA/gAAAAAA/gAAAAAALQAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAA2AAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAALQAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAALQAAAAAA/gAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAALQAAAAAA/gAAAAAALQAAAAAALQAAAAAAzgAAAAAAzgAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAzgAAAAAAzgAAAAAAzgAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAALQAAAAAAzgAAAAAAzgAAAAAAzgAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAswAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAwQAAAAAAwgAAAAAA/gAAAAAAwQAAAAAA/gAAAAAAswAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAwQAAAAAA/gAAAAAAswAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAwQAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAswAAAAAA/gAAAAAAswAAAAAA2AAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAoAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAswAAAAAAoAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAoAAAAAAAswAAAAAAoAAAAAAAswAAAAAA2AAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoAAAAAAAoAAAAAAAoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA2AAAAAAA2AAAAAAA2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
@@ -95,8 +95,7 @@ entities:
             0: 32768
             1: 78
           -1,2:
-            0: 8
-            2: 128
+            0: 136
             1: 305
           0,-1:
             0: 53244
@@ -119,9 +118,10 @@ entities:
           2,1:
             0: 51
           2,2:
-            1: 17508
+            0: 4352
+            1: 35048
           2,3:
-            1: 70
+            1: 142
           0,-2:
             1: 2188
           1,-2:
@@ -147,21 +147,6 @@ entities:
           moles:
           - 0
           - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 23.750458
-          - 79.51239
           - 0
           - 0
           - 0
@@ -392,8 +377,11 @@ entities:
   - uid: 319
     components:
     - type: Transform
-      pos: 2.4772606,7.546873
+      pos: 2.3657625,7.728075
       parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: CableApcExtension
   entities:
   - uid: 89
@@ -825,6 +813,29 @@ entities:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
+- proto: CrateCommandSecure
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 8.584726,10.414249
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      fixedRotation: False
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 111
+          - 112
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: CrateEngineering
   entities:
   - uid: 123
@@ -905,6 +916,21 @@ entities:
     - type: Transform
       pos: 9.5,5.5
       parent: 1
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,9.5
+      parent: 1
 - proto: EffectHearts
   entities:
   - uid: 303
@@ -919,6 +945,29 @@ entities:
     - type: Transform
       pos: 3.3486347,-3.5568118
       parent: 1
+- proto: EngineeringTechFabCircuitboard
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      parent: 84
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
 - proto: FaxMachineBase
   entities:
   - uid: 267
@@ -928,6 +977,13 @@ entities:
       parent: 1
     - type: FaxMachine
       name: Bridge
+- proto: filingCabinetRandom
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
 - proto: FoodMealGrilledCheese
   entities:
   - uid: 291
@@ -1207,12 +1263,7 @@ entities:
   - uid: 148
     components:
     - type: Transform
-      pos: 10.5,12.5
-      parent: 1
-  - uid: 149
-    components:
-    - type: Transform
-      pos: 10.5,9.5
+      pos: 9.5,11.5
       parent: 1
   - uid: 269
     components:
@@ -1257,12 +1308,7 @@ entities:
   - uid: 277
     components:
     - type: Transform
-      pos: 8.5,10.5
-      parent: 1
-  - uid: 278
-    components:
-    - type: Transform
-      pos: 8.5,11.5
+      pos: 9.5,10.5
       parent: 1
   - uid: 279
     components:
@@ -1309,6 +1355,16 @@ entities:
     - type: Transform
       pos: 8.5,2.5
       parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 11.5,12.5
+      parent: 1
 - proto: GrilleBroken
   entities:
   - uid: 225
@@ -1339,26 +1395,6 @@ entities:
     - type: Transform
       pos: 7.5,15.5
       parent: 1
-  - uid: 150
-    components:
-    - type: Transform
-      pos: 10.5,10.5
-      parent: 1
-  - uid: 151
-    components:
-    - type: Transform
-      pos: 10.5,11.5
-      parent: 1
-  - uid: 152
-    components:
-    - type: Transform
-      pos: 10.5,13.5
-      parent: 1
-  - uid: 153
-    components:
-    - type: Transform
-      pos: 10.5,8.5
-      parent: 1
   - uid: 285
     components:
     - type: Transform
@@ -1388,6 +1424,26 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-7.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 11.5,11.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 11.5,10.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 11.5,13.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 11.5,8.5
       parent: 1
 - proto: KitchenReagentGrinder
   entities:
@@ -1423,6 +1479,17 @@ entities:
     components:
     - type: Transform
       parent: 123
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: MedicalTechFabCircuitboard
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      parent: 84
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -1540,15 +1607,22 @@ entities:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 111
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 264
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 112
+- proto: RandomFoodBakedSingle
+  entities:
+  - uid: 326
     components:
     - type: Transform
-      pos: 1.5,7.5
+      pos: 2.5,5.5
       parent: 1
 - proto: RandomPosterAny
   entities:
@@ -1579,15 +1653,15 @@ entities:
       parent: 1
 - proto: RandomPosterContraband
   entities:
-  - uid: 309
-    components:
-    - type: Transform
-      pos: 5.5,-0.5
-      parent: 1
   - uid: 310
     components:
     - type: Transform
       pos: 1.5,-3.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
       parent: 1
 - proto: ResearchAndDevelopmentServerMachineCircuitboard
   entities:
@@ -1693,11 +1767,6 @@ entities:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 71
-    components:
-    - type: Transform
-      pos: 8.5,10.5
-      parent: 1
   - uid: 76
     components:
     - type: Transform
@@ -1723,15 +1792,20 @@ entities:
     - type: Transform
       pos: 7.5,13.5
       parent: 1
-  - uid: 84
-    components:
-    - type: Transform
-      pos: 8.5,11.5
-      parent: 1
   - uid: 113
     components:
     - type: Transform
       pos: -1.5,8.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 9.5,11.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 9.5,10.5
       parent: 1
 - proto: SignCryogenicsMed
   entities:
@@ -1804,7 +1878,7 @@ entities:
   - uid: 122
     components:
     - type: Transform
-      pos: 1.5190151,7.2696295
+      pos: 1.571353,7.335264
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -1814,7 +1888,7 @@ entities:
   - uid: 119
     components:
     - type: Transform
-      pos: 1.47049,7.727224
+      pos: 1.3603673,7.631648
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -1824,7 +1898,7 @@ entities:
   - uid: 120
     components:
     - type: Transform
-      pos: 1.5190151,7.642893
+      pos: 1.3452969,7.4708977
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -1834,18 +1908,17 @@ entities:
   - uid: 121
     components:
     - type: Transform
-      pos: 1.4270873,7.449446
+      pos: 1.571353,7.591461
       parent: 1
     - type: Physics
       angularDamping: 0
       linearDamping: 0
 - proto: VendingMachineCart
   entities:
-  - uid: 264
+  - uid: 332
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,10.5
+      pos: 8.5,11.5
       parent: 1
 - proto: VendingMachineChemicals
   entities:
@@ -1873,7 +1946,7 @@ entities:
   - uid: 107
     components:
     - type: Transform
-      pos: 2.370717,7.727272
+      pos: 2.626983,7.69291
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -1881,7 +1954,7 @@ entities:
   - uid: 110
     components:
     - type: Transform
-      pos: 2.5964115,7.701231
+      pos: 2.5164666,7.5522537
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -2213,6 +2286,16 @@ entities:
     components:
     - type: Transform
       pos: -0.5,6.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 9.5,12.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 9.5,9.5
       parent: 1
   - uid: 263
     components:

--- a/Resources/Migrations/eeMigration.yml
+++ b/Resources/Migrations/eeMigration.yml
@@ -10,12 +10,12 @@ PosterLegitSMEpi: PosterLegitSafetyMothEpi
 PosterLegitSMPills: PosterLegitSafetyMothPills
 PosterLegitSMAnomalies: PosterLegitSafetyMothDelam
 PosterLegitSMGlimmer: PosterLegitSafetyMothGlimmer
-EngineeringTechFab: Autolathe
-EngineeringTechFabCircuitboard: AutolatheMachineCircuitboard
-ScienceTechFab: Protolathe
-ScienceTechFabCircuitboard: ProtolatheMachineCircuitboard
-ServiceTechFab: Autolathe
-ServiceTechFabCircuitboard: AutolatheMachineCircuitboard
+#EngineeringTechFab: Autolathe
+#EngineeringTechFabCircuitboard: AutolatheMachineCircuitboard
+#ScienceTechFab: Protolathe
+#ScienceTechFabCircuitboard: ProtolatheMachineCircuitboard
+#ServiceTechFab: Autolathe
+#ServiceTechFabCircuitboard: AutolatheMachineCircuitboard
 
 # 2023-10-05
 FoodMothTomatoSauce: null

--- a/Resources/Prototypes/_Vulp/Entities/Stations/planet.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Stations/planet.yml
@@ -1,5 +1,5 @@
 - type: entity
-  id: PlanetStation
+  id: PlanetStationBase
   parent:
   - BaseStation
   - BaseStationNews

--- a/Resources/Prototypes/_Vulp/Entities/Structures/cryosleep.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Structures/cryosleep.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: CryogenicSleepUnit
+  id: CryogenicSleepUnitSpawnerNative
+  suffix: Spawner, Native
+  components:
+  - type: ContainerSpawnPoint
+    containerId: storage
+    spawnType: Job
+    job: Native

--- a/Resources/Prototypes/_Vulp/Maps/planet-bouba.yml
+++ b/Resources/Prototypes/_Vulp/Maps/planet-bouba.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   stations:
     bouba:
-      stationProto: PlanetStation
+      stationProto: PlanetStationBase
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Landing Shuttle'

--- a/Resources/Prototypes/_Vulp/Maps/planet-colony-drop-pod.yml
+++ b/Resources/Prototypes/_Vulp/Maps/planet-colony-drop-pod.yml
@@ -5,7 +5,7 @@
   minPlayers: 0
   stations:
     colony-drop-pod:
-      stationProto: PlanetStation
+      stationProto: PlanetStationBase
       components:
       - type: StationNameSetup
         mapNameTemplate: 'Colony Drop Pod'
@@ -14,6 +14,7 @@
           prefixCreator: 'NVS'
       - type: PlanetStation
         biome: Continental
+        mergeIntoPlanet: true
         components:
         - type: DayNightCycle
           timeEntries:

--- a/Resources/Prototypes/_Vulp/Roles/native.yml
+++ b/Resources/Prototypes/_Vulp/Roles/native.yml
@@ -4,6 +4,7 @@
   description: job-description-native
   playTimeTracker: JobNative
   startingGear: NativeGear
+  alwaysUseSpawner: true
   icon: JobIconNative
   supervisors: job-supervisors-noone
   access:


### PR DESCRIPTION
# Description
Improves the colony drop pod map and makes it merge onto the planet grid.
Adds the Native spawn point and fixes the bug that caused job-specific spawnpoints to not be prioritized over job-specific ones.

# Changelog
:cl:
- tweak: The colony drop pod has been improved, most importantly it now contains a defib, fire extinguishers, more lights, a medical techfab...
- tweak: The colony drop pod will now become part of the planet grid at round start, which means it can be easily be modified by players. However, players should be very careful when using the shipyard console as the incoming shuttle CAN flatten it now.