### PR TITLE
Seismic Charge Tweak

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -100,10 +100,10 @@
     ports:
     - Trigger
   - type: Explosive
-    explosionType: Cryo
-    totalIntensity: 120
+    explosionType: SeismicCharge
+    totalIntensity: 200
     intensitySlope: 2
-    maxIntensity: 30
+    maxIntensity: 10
     canCreateVacuum: false
   - type: ExplodeOnTrigger
 

--- a/Resources/Prototypes/explosion.yml
+++ b/Resources/Prototypes/explosion.yml
@@ -29,6 +29,23 @@
   texturePath: /Textures/Effects/fire.rsi
   fireStates: 3
 
+# Vulpstation
+- type: explosion
+  id: SeismicCharge
+  damagePerIntensity:
+    types:
+      Heat: 3
+      Blunt: 3
+      Piercing: 3
+      Structural: 25 # At 10 intensity (the limit), 250 structural
+  tileBreakChance: [ 0, 0.5, 1 ]
+  tileBreakIntensity: [ 0, 5, 10 ]
+  tileBreakRerollReduction: 20
+  intensityPerState: 5
+  lightColor: Purple
+  texturePath: /Textures/Effects/fire.rsi
+  fireStates: 3
+
 - type: explosion
   id: MicroBomb
   damagePerIntensity:


### PR DESCRIPTION
# Description
Added a special explosion type for it, meant to deal a lot of damage to rocks, but not so much to people.

# Changelog
:cl:
- tweak: Seismic charges should now be more effective at clearing rocks (and other structures!)
