### PR TITLE
Another Wave of Fixes and Tweaks

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -466,7 +466,7 @@ namespace Content.Server.Administration.Managers
             }
         }
 
-        private static bool IsLocal(ICommonSession player)
+        public static bool IsLocal(ICommonSession player) // Vulp - made public
         {
             var ep = player.Channel.RemoteEndPoint;
             var addr = ep.Address;

--- a/Content.Server/NPC/Pathfinding/PathfindingSystem.Common.cs
+++ b/Content.Server/NPC/Pathfinding/PathfindingSystem.Common.cs
@@ -45,7 +45,7 @@ public sealed partial class PathfindingSystem
 
         // TODO
         if ((end.Data.Flags & PathfindingBreadcrumbFlag.Space) != 0x0 &&
-            (!TryComp<GravityComponent>(end.GraphUid, out var gravity) || !gravity.Enabled))
+            /*(!TryComp<GravityComponent>(end.GraphUid, out var gravity) || !gravity.Enabled)*/ true) // Vulpstation - don't pathfind into space
         {
             return 0f;
         }

--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -33,9 +33,10 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
         JobPrototype? jobProto = null;
 
         // If it's just a spawn pref check if it's for cryo (silly).
-        if (args.HumanoidCharacterProfile?.SpawnPriority != SpawnPriorityPreference.Cryosleep &&
-            (!_proto.TryIndex(args.Job?.Prototype, out jobProto) || jobProto.JobEntity == null))
-            return;
+        // Vulpstation - no. Who though it's a good idea to split those into two systems and yet not have them communicate?
+        // if (args.HumanoidCharacterProfile?.SpawnPriority != SpawnPriorityPreference.Cryosleep &&
+        //     (!_proto.TryIndex(args.Job?.Prototype, out jobProto) || jobProto.JobEntity == null))
+        //     return;
 
         if (jobProto == null && !_proto.TryIndex(args.Job?.Prototype, out jobProto))
             return;

--- a/Content.Server/_Vulp/Admin/AccountAgeCheckerSystem.cs
+++ b/Content.Server/_Vulp/Admin/AccountAgeCheckerSystem.cs
@@ -1,0 +1,92 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Content.Server.Administration.Managers;
+using Content.Server.Chat.Managers;
+using Content.Shared._Vulp;
+using Robust.Server.Player;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+
+namespace Content.Server._Vulp.Admin;
+
+
+public sealed class AccountAgeCheckerSystem : EntitySystem
+{
+    [Dependency] private readonly INetManager _netMan = default!;
+    [Dependency] private readonly IPlayerManager _playerMan = default!;
+    [Dependency] private readonly IChatManager _chatMan = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IHttpClientHolder _http = default!;
+
+    private bool _checkLocal;
+    private int _minDays;
+    private string _authServer = string.Empty;
+    private List<INetChannel> _deniedChannels = new();
+
+    public override void Initialize()
+    {
+        _netMan.Connected += (_, args) => Task.Run(() => CheckAccountAge(args.Channel));
+
+        Subs.CVar(_cfg, VulpCCVars.CheckLocalhostAccountAge, it => _checkLocal = it, true);
+        Subs.CVar(_cfg, VulpCCVars.MinimumAccountAgeDays, it => _minDays = it, true);
+        Subs.CVar(_cfg, CVars.AuthServer, it => _authServer = it, true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        // You may be screaming in terror reading this code, asking "why?!"
+        // Well... it's because IoC is thread-local. And Loc.GetString used in SendAdminAlert always invoked IoC.
+        lock (_deniedChannels)
+        {
+            foreach (var channel in _deniedChannels)
+                _chatMan.SendAdminAlert($"User {channel.UserName}: failed to fetch account age. See server logs for details.");
+
+            _deniedChannels.Clear();
+        }
+    }
+
+    public async void CheckAccountAge(INetChannel channel)
+    {
+        try
+        {
+            var session = _playerMan.GetSessionByChannel(channel);
+            var isLocal = AdminManager.IsLocal(session);
+            if (!_checkLocal && (channel.AuthType != LoginType.LoggedIn || isLocal))
+                return;
+
+            var name = channel.UserData.UserName;
+            if (isLocal && name.StartsWith("localhost@"))
+                name = name["localhost@".Length..];
+
+            var url = $"{_authServer}api/query/name?name={Uri.EscapeDataString(name)}";
+            await DoChecks(session, url);
+        }
+        catch (Exception e)
+        {
+            Log.Error($"Failed to check account age for {channel.UserName}: {e.Message}");
+            lock (_deniedChannels)
+                _deniedChannels.Add(channel);
+        }
+    }
+
+    private async Task DoChecks(ICommonSession session, string url)
+    {
+        var data = await _http.Client.GetFromJsonAsync<UserDataResponse>(url);
+        if (data is null)
+            throw new($"Unknown error");
+
+        var age = DateTime.UtcNow - data.CreatedTime.UtcDateTime;
+        Log.Info($"User {session.Name}: account age is {age.TotalDays} days");
+        if (age.TotalDays >= _minDays)
+            return;
+
+        session.Channel.Disconnect("Your SS14 account is too young.");
+    }
+
+    private sealed record UserDataResponse(string UserName, Guid UserId, DateTimeOffset CreatedTime);
+}

--- a/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.cs
+++ b/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.cs
@@ -141,12 +141,16 @@ public sealed partial class PlanetStationSystem : EntitySystem
             detachedEntities.Add((uid, position, rotation));
         }
 
+        var offset = _xforms.GetWorldPosition(target) - _xforms.GetWorldPosition(source);
+        // All entities on the source grid are going to be offset from the target grid by this value
+        var misalign = new Vector2(offset.X % 1f, offset.Y % 1f);
+
         _gridFixtures.Merge(target, source, Transform(source).LocalMatrix);
 
         foreach (var entity in detachedEntities)
         {
             _xforms.SetParent(entity.uid, target);
-            _xforms.SetWorldPositionRotation(entity.uid, entity.worldPos, entity.worldRot);
+            _xforms.SetWorldPositionRotation(entity.uid, entity.worldPos - misalign, entity.worldRot);
         }
     }
 

--- a/Content.Shared/_Vulp/VulpCCVars.cs
+++ b/Content.Shared/_Vulp/VulpCCVars.cs
@@ -9,6 +9,18 @@ namespace Content.Shared._Vulp;
 public sealed class VulpCCVars
 {
     /// <summary>
+    ///     The minimum age below which connections will be denied. Less or equal to 0 to disable.
+    /// </summary>
+    public static readonly CVarDef<int> MinimumAccountAgeDays =
+        CVarDef.Create("admin.minimum_account_age_days", 14, CVar.SERVER);
+
+    /// <summary>
+    ///     Whether to enable account age checks for local players.
+    /// </summary>
+    public static readonly CVarDef<bool> CheckLocalhostAccountAge =
+        CVarDef.Create("admin.minimum_account_age_check_localhost", false, CVar.SERVER);
+
+    /// <summary>
     ///     Whether to start a public vote before automatically sending the emergency shuttle.
     /// </summary>
     public static readonly CVarDef<bool> DoEvacVotes =

--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -126,7 +126,9 @@ guide-entry-glossary = Glossary
 guide-entry-altars-golemancy = Altars and Golemancy
 guide-entry-glimmer-creatures = Glimmer Creatures
 guide-entry-reverse-engineering = Reverse Engineering
-   
+# Vulpstation
+guide-entry-glimmer-management = Glimmer Management
+
 
 guide-entry-loadout-info = Loadouts
 guide-entry-loadout-eyes-eyepatch = Eyepatch

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/solar.yml
@@ -61,6 +61,7 @@
     supplyRampTolerance: 1000
     supplyRampRate: 1000
   - type: SolarPanel
+    maxSupply: 1200 # Vulpstation - buffed compared to default 750 watts
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Guidebook/science.yml
+++ b/Resources/Prototypes/Guidebook/science.yml
@@ -12,6 +12,7 @@
   - ReverseEngineering
   - GlimmerCreatures
   - TraversalDistorter
+  - GlimmerManagement # Vulpstation
 
 - type: guideEntry
   id: Technologies
@@ -82,3 +83,9 @@
   id: GlimmerCreatures
   name: guide-entry-glimmer-creatures
   text: /ServerInfo/Guidebook/DeltaV/Epistemics/GlimmerCreatures.xml
+
+# Vulpstation
+- type: guideEntry
+  id: GlimmerManagement
+  name: guide-entry-glimmer-management
+  text: /ServerInfo/_Vulp/Guidebook/Epistemics/GlimmerManagement.xml

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -681,17 +681,31 @@
   targetDepth: 9 # Floof - Make it so they can actually occur
   effectHint: artifact-effect-hint-destruction
   components:
-  - type: SpawnArtifact
-    maxSpawns: 1
-    spawns:
-    - id: Singularity
+# Vulpstation - no, just explode instead
+#  - type: SpawnArtifact
+#    maxSpawns: 1
+#    spawns:
+#    - id: Singularity
+  - type: Explosive
+    deleteAfterExplosion: false
+    explosionType: Default
+    totalIntensity: 1000
+    intensitySlope: 2
+    maxIntensity: 10
 
 - type: artifactEffect
   id: EffectTesla
   targetDepth: 9 # Floof - Make it so they can actually occur
   effectHint: artifact-effect-hint-destruction
   components:
-  - type: SpawnArtifact
-    maxSpawns: 1
-    spawns:
-    - id: TeslaEnergyBall
+  # Vulpstation - no, just explode instead
+#  - type: SpawnArtifact
+#    maxSpawns: 1
+#    spawns:
+#    - id: TeslaEnergyBall
+  - type: Explosive
+    deleteAfterExplosion: false
+    explosionType: Cryo
+    totalIntensity: 500 # Cryo explosion has way more damage per intensity, primarily structural
+    intensitySlope: 2
+    maxIntensity: 10

--- a/Resources/Prototypes/_Floof/Gamerules/Cargo_gifts.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/Cargo_gifts.yml
@@ -4,7 +4,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
-    weight: 10
+    weight: 0.5
     startDelay: 10
     reoccurrenceDelay: 120
     duration: 120

--- a/Resources/Prototypes/_Vulp/Entities/Markers/spawners.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Markers/spawners.yml
@@ -1,0 +1,98 @@
+- type: entity
+  name: Random Animal Spawner
+  id: PlanetAnimalSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Mobs/Animals/chicken.rsi
+      state: icon-1
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: PlanetAnimalTable
+      prob: 0.6
+
+- type: entityTable
+  id: PlanetAnimalTable
+  table: !type:GroupSelector
+    children:
+    # Chickens
+    - !type:GroupSelector
+      weight: 2
+      rolls: !type:RangeNumberSelector
+        range: 2, 4
+      children:
+      - id: MobChicken
+      - id: MobChicken1
+      - id: MobChicken2
+    # Ducks
+    - !type:GroupSelector
+      weight: 0.8
+      rolls: !type:RangeNumberSelector
+        range: 2, 4
+      children:
+      - id: MobDuckMallard
+      - id: MobDuckWhite
+      - id: MobDuckBrown
+    # Cows
+    - id: MobCow
+      rolls: !type:RangeNumberSelector
+        range: 1, 2
+      weight: 0.4
+    # Goat
+    - id: MobGoat
+      weight: 0.2
+    # Pig
+    - id: MobPig
+      weight: 0.9
+    # Misc
+    - id: MobMonkey
+      weight: 0.2
+    - id: MobParrot
+      weight: 0.05
+    - id: MobPenguin
+      weight: 0.001
+    - !type:GroupSelector
+      weight: 0.05
+      children:
+      - id: MobPossum
+      - id: MobPossumOld
+    - id: MobRaccoon
+      weight: 0.05
+    # Fox
+    - !type:GroupSelector
+      weight: 0.1 # Foxxo <3
+      rolls: !type:RangeNumberSelector
+        range: 1, 2
+      children:
+      - id: MobFox
+        weight: 5
+      - id: MobArcticFox
+    # Cat
+    - id: MobCat
+      rolls: !type:RangeNumberSelector
+        range: 1, 2
+      weight: 0.05
+    # Dangerous
+    - !type:GroupSelector
+      weight: 0.05
+      children:
+      # Spider nest
+      - !type:AllSelector
+        children:
+        - id: MobGiantSpiderAngry
+          amount: !type:ConstantNumberSelector { value: 2 }
+        - id: WebNest
+      # Xeno hive
+      - !type:AllSelector
+        weight: 0.5
+        children:
+        - id: MobXenoQueen
+        - id: MobXenoDefender
+          rolls: !type:RangeNumberSelector
+            range: 0, 2
+        - id: MobXenoRavager
+          rolls: !type:RangeNumberSelector
+            range: 2, 3
+

--- a/Resources/Prototypes/_Vulp/Entities/Markers/spawners.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Markers/spawners.yml
@@ -19,9 +19,9 @@
     children:
     # Chickens
     - !type:GroupSelector
-      weight: 2
+      weight: 1.6
       rolls: !type:RangeNumberSelector
-        range: 2, 4
+        range: 1, 3
       children:
       - id: MobChicken
       - id: MobChicken1
@@ -30,7 +30,7 @@
     - !type:GroupSelector
       weight: 0.8
       rolls: !type:RangeNumberSelector
-        range: 2, 4
+        range: 1, 3
       children:
       - id: MobDuckMallard
       - id: MobDuckWhite
@@ -75,6 +75,7 @@
         range: 1, 2
       weight: 0.05
     # Dangerous
+    # TODO separate into a nested selector
     - !type:GroupSelector
       weight: 0.05
       children:

--- a/Resources/Prototypes/_Vulp/Procedural/biome_loot.yml
+++ b/Resources/Prototypes/_Vulp/Procedural/biome_loot.yml
@@ -12,3 +12,10 @@
   loots:
   - !type:BiomeMarkerLoot
     proto: Lizards
+
+- type: salvageLoot
+  id: MiscAnimals
+  guaranteed: true
+  loots:
+  - !type:BiomeMarkerLoot
+    proto: MiscAnimals

--- a/Resources/Prototypes/_Vulp/Procedural/biome_templates.yml
+++ b/Resources/Prototypes/_Vulp/Procedural/biome_templates.yml
@@ -1,13 +1,13 @@
 - type: biomeMarkerLayer
   id: CritterSpawnLocations
   prototype: VentEventSpawnerWeight5
-  radius: 18
+  radius: 16
   minGroupSize: 1
   maxGroupSize: 5
 
 - type: biomeMarkerLayer
   id: MiscAnimals
   prototype: PlanetAnimalSpawner
-  radius: 9
+  radius: 20
   minGroupSize: 1
   maxGroupSize: 1

--- a/Resources/Prototypes/_Vulp/Procedural/biome_templates.yml
+++ b/Resources/Prototypes/_Vulp/Procedural/biome_templates.yml
@@ -4,3 +4,10 @@
   radius: 18
   minGroupSize: 1
   maxGroupSize: 5
+
+- type: biomeMarkerLayer
+  id: MiscAnimals
+  prototype: PlanetAnimalSpawner
+  radius: 9
+  minGroupSize: 1
+  maxGroupSize: 1

--- a/Resources/ServerInfo/_Vulp/Guidebook/Epistemics/GlimmerManagement.xml
+++ b/Resources/ServerInfo/_Vulp/Guidebook/Epistemics/GlimmerManagement.xml
@@ -1,0 +1,120 @@
+<Document>
+
+  [head=1]Glimmer Management[/head]
+
+  Glimmer in Space Station 14 represents the amount of noospheric pressure in the world.
+  Unlike regular pressure however, the glimmer field is pretty uniform throughout the universe,
+  such that glimmer fluctuations on one planet or station may affect the entire solar system.
+
+  Most outside of the Epistemics department will not be tasked with helping manage glimmer,
+  however, it can pay to know a thing or two about glimmer if you are a psionic.
+
+  The most obvious way to measure glimmer is to ask Sophia (the glimmer scribe), which can typically be found within or near
+  the Epistemics department.
+
+  <Box Orientation="Horizontal">
+    <GuideEntityEmbed Entity="SophicScribe" Caption="Sofia"/>
+  </Box>
+
+  This statue will send alerts to the Epistemics department on the current glimmer status,
+  but anyone may walk up to it and interact with it for a current status update.
+
+  Epistemics PDAs also contain a pre-installed app that can be used to see the current glimmer level and the glimmer chart.
+  You may be able to ask your fellow epistemics members to measure it.
+
+  <Box Orientation="Horizontal">
+    <GuideEntityEmbed Entity="SciencePDA" Caption="Epistemics PDA"/>
+    <GuideEntityEmbed Entity="GlimmerMonitorCartridge" Caption="Glimmer Monitor Cartridge"/>
+  </Box>
+
+
+  [head=1]Dangers[/head]
+  Starting with the basics of why you would want to manage glimmer in the first place.
+  If it gets too high, some undesirable things will start to happen,
+  and some of those things may even cause a further increase in the glimmer level, causing a destructive cascade.
+
+  Examples include both passive entities like anomalies being generated and certain hostile entities appearing around the station.
+
+  <Box Orientation="Horizontal">
+    <GuideEntityEmbed Entity="MobGlimmerMite" Caption="Glimmer mite"/>
+    <GuideEntityEmbed Entity="MobGlimmerWisp" Caption="Glimmer wisp"/>
+    <GuideEntityEmbed Entity="MobRevenant" Caption="Revenant"/>
+  </Box>
+
+  In order to avoid the most destructive of these things, glimmer should generally be kept under 450 milipsi,
+  and if glimmer reaches 1000 milipsi (1 psi), a noospheric collapse may occur, erasing the bonds between souls and vessels,
+  and the border between reality and imagination.
+
+  This can lead to a variety of negative consequences ranging from a mass mindswap to complete destruction of reality,
+  and must be avoided at all costs.
+
+  [head=1]Benefits[/head]
+  What is less obvious is that those who have a connection with the noosphere are more likely to gain psionic powers the higher the noospheric pressure is.
+  Noospheric discharges can stun psionics, but will also clear their mental blocks and allow them to gain new psionic powers.
+
+  Oracle will also provide more generous gifts for fulfilling its orders when glimmer levels are high.
+
+  [head=1]Raising Glimmer[/head]
+  Glimmer can be raised in a number of ways:
+
+  Firstly, the most common is the use of psionic powers.
+  Each psionic user has their own amplification and dampening, which determine the force and control they have over their powers.
+  The higher their amplification is, the more powerful are the effects their powers have on the world, but also the more glimmer their usage produces.
+  Having more psionic powers generally leads to a higher amplification. Therefore, rogue psionics can be a big threat.
+
+  Secondly, Anomalies and certain other psionic entities, such as glimmer mites, generate a constant stream of glimmer for as long as they are active.
+  If glimmer levels are getting high, it may be desirable to get rid of those.
+
+  Thirdly, Extracting research from artifacts increases glimmer, so it's recommended to ensure that xenoarchelogy is on pause when glimmer is too high.
+  The standard rate is 1 milipsi of glimmer for each 1 kilopoint of research.
+
+  Finally, an active Glimmer Prober generates glimmer constantly in exchange for research points,
+  these expensive objects can be used to generate passive income but should be watched carefully.
+  If glimmer level exceeds 500 milipsi, they will start powering themselves with the noospheric energy and become impossible to turn off,
+  leading to a dangerous cascade.
+
+  <Box Orientation="Horizontal">
+    <GuideEntityEmbed Entity="GlimmerProber" Caption="Prober"/>
+    <GuideEntityEmbed Entity="AnomalyBluespace" Caption="Anomaly"/>
+  </Box>
+
+  [head=1]Lowering Glimmer[/head]
+  There are 4 ways to lower glimmer, the most common is with time.
+  Noospheric pressure slowly but constantly loosens over time, so halting all noospheric activity will generally lower the glimmer level.
+
+  The second is by waiting for a noospheric discharge or another noospheric event to occur.
+  During those discharges, some of the excess noospheric pressure manifests into a physical entity or energy burst.
+  For example, it can create glimmer mites, a revenant, a wisp; perhaps duplicate an existing glimmer prober or cause one to explode.
+  All of those effects simultaneously lower the glimmer level.
+
+  The most proactive way is by creating a glimmer drain, which uses power to stabilize the noosphere.
+  In order to create it, you will need to insert 5 normality crystals into the glimmer prober frame.
+
+  There are a few ways to acquire normality: oracle can give it as a reward for fulfilling an order,
+  you can find it in the form of raw normality ore on the planet surface, or you can use chemistry to synthesize it.
+  The latter requires ectoplasm, which can be found inside glimmer mites, revenants, and wisps (you will need to grind those).
+
+  The recipe for synthesizing normality is as follows:
+
+  <Box Orientation="Vertical">
+    <GuideEntityEmbed Entity="LargeBeaker" Caption="Take a beaker"/>
+    <Label Text="Add 5 units of ectoplasm"/>
+    <Label Text="Add 5 units of ash"/>
+    <Label Text="Add 5 units of red blood"/>
+    <Label Text="Add 5 units of water"/>
+    <Label Text="Add 5 units of liquid plasma as a catalyst"/>
+    <GuideEntityEmbed Entity="LargeBeaker" Captain="Heat to 200°C"/>
+  </Box>
+
+  Finally, In dire circumstances, when glimmer levels are extremely high, and you need to buy time, you can sacrifice a psionic on the altar.
+  This is done by placing someone on the altar and sacrificing them using a sharp object (use the right click menu for this).
+  In most cases, this will be considered a murder, so make sure to negotiate it with the command staff first.
+
+  (OOC note: unless you are an antag, OOC consent of the sacrificed person - whether explicit or implicit - is required)
+
+  <Box Orientation="Vertical">
+    <GuideEntityEmbed Entity="AltarFangs" Caption="Altar"/>
+    <GuideEntityEmbed Entity="KitchenKnife" Caption="Sharp object"/>
+  </Box>
+
+</Document>

--- a/Resources/ServerInfo/_Vulp/Guidebook/Epistemics/GlimmerManagement.xml
+++ b/Resources/ServerInfo/_Vulp/Guidebook/Epistemics/GlimmerManagement.xml
@@ -29,6 +29,7 @@
 
 
   [head=1]Dangers[/head]
+
   Starting with the basics of why you would want to manage glimmer in the first place.
   If it gets too high, some undesirable things will start to happen,
   and some of those things may even cause a further increase in the glimmer level, causing a destructive cascade.
@@ -49,12 +50,14 @@
   and must be avoided at all costs.
 
   [head=1]Benefits[/head]
+
   What is less obvious is that those who have a connection with the noosphere are more likely to gain psionic powers the higher the noospheric pressure is.
   Noospheric discharges can stun psionics, but will also clear their mental blocks and allow them to gain new psionic powers.
 
   Oracle will also provide more generous gifts for fulfilling its orders when glimmer levels are high.
 
   [head=1]Raising Glimmer[/head]
+
   Glimmer can be raised in a number of ways:
 
   Firstly, the most common is the use of psionic powers.
@@ -79,6 +82,7 @@
   </Box>
 
   [head=1]Lowering Glimmer[/head]
+
   There are 4 ways to lower glimmer, the most common is with time.
   Noospheric pressure slowly but constantly loosens over time, so halting all noospheric activity will generally lower the glimmer level.
 
@@ -96,14 +100,18 @@
 
   The recipe for synthesizing normality is as follows:
 
-  <Box Orientation="Vertical">
-    <GuideEntityEmbed Entity="LargeBeaker" Caption="Take a beaker"/>
-    <Label Text="Add 5 units of ectoplasm"/>
-    <Label Text="Add 5 units of ash"/>
-    <Label Text="Add 5 units of red blood"/>
-    <Label Text="Add 5 units of water"/>
-    <Label Text="Add 5 units of liquid plasma as a catalyst"/>
-    <GuideEntityEmbed Entity="LargeBeaker" Captain="Heat to 200°C"/>
+  <Box Orientation="Horizontal">
+    <Box Orientation="Vertical">
+      <GuideEntityEmbed Entity="LargeBeaker" Caption="Take a beaker"/>
+      <GuideEntityEmbed Entity="ChemistryHotplate" Caption="Heat to 200°C"/>
+    </Box>
+    <Box Orientation="Vertical">
+      - Add 5 units of ectoplasm
+      - Add 5 units of ash
+      - Add 5 units of red blood
+      - Add 5 units of water
+      - Add 5 units of liquid plasma as a catalyst
+    </Box>
   </Box>
 
   Finally, In dire circumstances, when glimmer levels are extremely high, and you need to buy time, you can sacrifice a psionic on the altar.


### PR DESCRIPTION
# Description
Testing is needed

# Changelog
:cl:
- add: More random animals can now spawn in packs around the planet. This includes some dangerous ones!
- add: Added a guidebook entry on glimmer management, thanks to Bandw2.
- add: Users whose ss14 accounts are younger than 14 days can no longer join the server.
- fix: All players should now default to spawning in cryo, regardless of their preferences.
- tweak: Station-wide destruction artifacts no longer spawn a singulo or tesla, but instead create an extremely powerful explosion.
- tweak: Solars now produce about 1.7 times more power.