### PR TITLE
Fix Server-Side Trait System Not Accounting for TraitPrototype.Slots

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -79,7 +79,7 @@ public sealed class TraitSystem : EntitySystem
 
             // To check for cheaters. :FaridaBirb.png:
             pointsTotal += traitPrototype.Points;
-            --traitSelections;
+            traitSelections -= traitPrototype.Slots;
         }
 
         if (pointsTotal < 0 || traitSelections < 0)


### PR DESCRIPTION
# Description
Shticode. My shitcode.

# Changelog
:cl:
- fix: Fixed the bug where trait balance validation would count traits that are meant to occupy 0 slots as occupying 1 slot.