### PR TITLE
Tradepost tweaks

### DIFF
--- a/Resources/Maps/_Vulp/StartingShuttles/tradepost.yml
+++ b/Resources/Maps/_Vulp/StartingShuttles/tradepost.yml
@@ -38,7 +38,7 @@ entities:
       chunks:
         0,0:
           ind: 0,0
-          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAkgAAAAAAkgAAAAAAkgAAAAAA/gAAAAAAkgAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAAkgAAAAAAkgAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAAkgAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAAkgAAAAAAkgAAAAAAkgAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAAgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAkgAAAAAAkgAAAAAAkgAAAAAA/gAAAAAAkgAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAA/gAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAkgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAAkgAAAAAAkgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAAoAAAAAAAoAAAAAAAoAAAAAAAkgAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAAkgAAAAAAkgAAAAAAkgAAAAAA/gAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
@@ -50,15 +50,15 @@ entities:
           version: 6
         -1,0:
           ind: -1,0
-          tiles: AAAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAA0QAAAAAD0QAAAAAD0QAAAAAD0QAAAAAB0QAAAAAC0QAAAAAD/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA0QAAAAAD0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAB0QAAAAAD/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA0QAAAAAB0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAD0QAAAAAC/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAALwAAAAAALwAAAAAAAAAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA0QAAAAAC0QAAAAAC0QAAAAAD/gAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAD0QAAAAAB0QAAAAAD0QAAAAAB0QAAAAAC0QAAAAAD/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAD/gAAAAAA0QAAAAAD0QAAAAAD0QAAAAAB0QAAAAAD/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0QAAAAAD0QAAAAAC0QAAAAAC0QAAAAAC/gAAAAAA0QAAAAAD/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAC/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAADLwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAC0QAAAAAD0QAAAAADLwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA0QAAAAAC0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAC/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAC/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAD/gAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA
+          tiles: AAAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAQAAAAAAAQAAAAAA0QAAAAAD0QAAAAAD0QAAAAAD0QAAAAAB0QAAAAAC0QAAAAAD/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA0QAAAAAD0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAB0QAAAAAD/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA0QAAAAAB0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAD0QAAAAAC/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAALwAAAAAALwAAAAAAAAAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA0QAAAAAC0QAAAAAC0QAAAAAD/gAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAD0QAAAAAB0QAAAAAD0QAAAAAB0QAAAAAC0QAAAAAD/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAD/gAAAAAA0QAAAAAD0QAAAAAD0QAAAAAB0QAAAAAD/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAD0QAAAAAC0QAAAAAC0QAAAAAC/gAAAAAA0QAAAAAD/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAC/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAADLwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAC0QAAAAAD0QAAAAADLwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0QAAAAAC0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAC/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAC/gAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0QAAAAAD0QAAAAAD0QAAAAAC0QAAAAAD/gAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -1,1:
           ind: -1,1
-          tiles: /gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAB/gAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: /gAAAAAA0QAAAAAC0QAAAAAD0QAAAAAC0QAAAAAB/gAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         0,1:
           ind: 0,1
-          tiles: LwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAAkgAAAAAAkgAAAAAAkgAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAAkgAAAAAAkgAAAAAA/gAAAAAAkQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA0wAAAAAD/gAAAAAA/gAAAAAA/gAAAAAAkQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0wAAAAAD0wAAAAAC0wAAAAAD0wAAAAAD0wAAAAAB/gAAAAAAkQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA0wAAAAAA0wAAAAAC0wAAAAAD0wAAAAAD/gAAAAAAkQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA0wAAAAAA0wAAAAAA0wAAAAAD0wAAAAAD/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA0wAAAAAC0wAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: LwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAAkgAAAAAAkgAAAAAAkgAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAAkgAAAAAAkgAAAAAA/gAAAAAAkQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA0wAAAAAD/gAAAAAA/gAAAAAA/gAAAAAAkQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0wAAAAAD0wAAAAAC0wAAAAAD0wAAAAAD0wAAAAAB/gAAAAAAkQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA0wAAAAAA0wAAAAAC0wAAAAAD0wAAAAAD/gAAAAAAkQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA0wAAAAAA0wAAAAAA0wAAAAAD0wAAAAAD/gAAAAAA/gAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA0wAAAAAC0wAAAAAA/gAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAA/gAAAAAA/gAAAAAA/gAAAAAA/gAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -2,0:
           ind: -2,0
@@ -863,36 +863,28 @@ entities:
             0: 255
           -1,1:
             0: 5055
-          0,2:
-            0: 65535
-          -1,2:
-            0: 61439
           0,3:
-            0: 65535
-          -1,3:
-            0: 61166
+            0: 59392
           0,4:
-            0: 255
+            0: 65535
           1,0:
             0: 65535
           1,1:
             0: 141
-          1,2:
-            0: 65535
           1,3:
-            0: 65535
+            0: 65520
           1,-1:
             0: 62236
           1,4:
-            0: 255
+            0: 65535
           2,0:
             0: 4151
           2,1:
             0: 62463
-          2,2:
-            0: 46015
           2,3:
             0: 48059
+          2,2:
+            0: 46015
           2,4:
             0: 59579
           2,-1:
@@ -906,11 +898,11 @@ entities:
           3,4:
             0: 47295
           3,0:
-            0: 12
+            0: 206
           3,-1:
             0: 61438
           4,0:
-            0: 2275
+            0: 2291
           4,1:
             0: 3953
           4,2:
@@ -1011,12 +1003,32 @@ entities:
             0: 65419
           -2,3:
             0: 3
-          -1,4:
-            0: 238
+          -1,2:
+            0: 273
           -4,5:
             0: 8
+          -1,4:
+            0: 61166
+          -1,5:
+            0: 61166
+          -1,6:
+            0: 52974
+          0,5:
+            0: 65535
+          0,6:
+            0: 65535
+          -1,7:
+            0: 8
+          0,7:
+            0: 47
+          1,5:
+            0: 65535
+          1,6:
+            0: 16383
           2,5:
-            0: 204
+            0: 12764
+          2,6:
+            0: 1
           3,5:
             0: 827
           4,4:
@@ -1199,7 +1211,7 @@ entities:
       pos: -10.5,7.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -1143.6953
+      secondsUntilStateChange: -2684.8633
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -1996,6 +2008,36 @@ entities:
     - type: Transform
       pos: 12.5,8.5
       parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
   - uid: 981
     components:
     - type: Transform
@@ -2651,11 +2693,6 @@ entities:
     - type: Transform
       pos: 7.5,17.5
       parent: 1
-  - uid: 1370
-    components:
-    - type: Transform
-      pos: 6.5,17.5
-      parent: 1
   - uid: 1371
     components:
     - type: Transform
@@ -2701,130 +2738,105 @@ entities:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 1380
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 1
-  - uid: 1381
-    components:
-    - type: Transform
-      pos: -2.5,15.5
-      parent: 1
-  - uid: 1382
-    components:
-    - type: Transform
-      pos: -2.5,14.5
-      parent: 1
-  - uid: 1383
-    components:
-    - type: Transform
-      pos: -2.5,12.5
-      parent: 1
-  - uid: 1384
-    components:
-    - type: Transform
-      pos: -2.5,11.5
-      parent: 1
   - uid: 1385
     components:
     - type: Transform
-      pos: -2.5,10.5
+      pos: 7.5,18.5
       parent: 1
   - uid: 1386
     components:
     - type: Transform
-      pos: -2.5,9.5
+      pos: 7.5,19.5
       parent: 1
   - uid: 1387
     components:
     - type: Transform
-      pos: -2.5,8.5
+      pos: 7.5,20.5
       parent: 1
   - uid: 1388
     components:
     - type: Transform
-      pos: -2.5,13.5
+      pos: 7.5,21.5
       parent: 1
   - uid: 1389
     components:
     - type: Transform
-      pos: -1.5,8.5
+      pos: 7.5,22.5
       parent: 1
   - uid: 1390
     components:
     - type: Transform
-      pos: -0.5,8.5
+      pos: 7.5,23.5
       parent: 1
   - uid: 1391
     components:
     - type: Transform
-      pos: 0.5,8.5
+      pos: 7.5,24.5
       parent: 1
   - uid: 1392
     components:
     - type: Transform
-      pos: 1.5,8.5
+      pos: 7.5,25.5
       parent: 1
   - uid: 1393
     components:
     - type: Transform
-      pos: 2.5,8.5
+      pos: 7.5,26.5
       parent: 1
   - uid: 1394
     components:
     - type: Transform
-      pos: 3.5,8.5
+      pos: 5.5,26.5
       parent: 1
   - uid: 1395
     components:
     - type: Transform
-      pos: 4.5,8.5
+      pos: 6.5,26.5
       parent: 1
   - uid: 1396
     components:
     - type: Transform
-      pos: 5.5,8.5
+      pos: 4.5,26.5
       parent: 1
   - uid: 1397
     components:
     - type: Transform
-      pos: 6.5,8.5
+      pos: 3.5,26.5
       parent: 1
   - uid: 1398
     components:
     - type: Transform
-      pos: 7.5,8.5
+      pos: 2.5,26.5
       parent: 1
   - uid: 1399
     components:
     - type: Transform
-      pos: 7.5,9.5
+      pos: 1.5,26.5
       parent: 1
   - uid: 1400
     components:
     - type: Transform
-      pos: 7.5,10.5
+      pos: 0.5,26.5
       parent: 1
   - uid: 1401
     components:
     - type: Transform
-      pos: 7.5,11.5
+      pos: -0.5,26.5
       parent: 1
   - uid: 1402
     components:
     - type: Transform
-      pos: 7.5,12.5
+      pos: -1.5,26.5
       parent: 1
   - uid: 1403
     components:
     - type: Transform
-      pos: 7.5,13.5
+      pos: -2.5,26.5
       parent: 1
   - uid: 1404
     components:
     - type: Transform
-      pos: 8.5,13.5
+      pos: -2.5,25.5
       parent: 1
   - uid: 1411
     components:
@@ -2876,6 +2888,11 @@ entities:
     - type: Transform
       pos: 14.5,6.5
       parent: 1
+  - uid: 1423
+    components:
+    - type: Transform
+      pos: -2.5,24.5
+      parent: 1
   - uid: 1491
     components:
     - type: Transform
@@ -2891,202 +2908,92 @@ entities:
     - type: Transform
       pos: -5.5,-11.5
       parent: 1
+  - uid: 1547
+    components:
+    - type: Transform
+      pos: -2.5,23.5
+      parent: 1
+  - uid: 1548
+    components:
+    - type: Transform
+      pos: -2.5,22.5
+      parent: 1
+  - uid: 1549
+    components:
+    - type: Transform
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 1550
+    components:
+    - type: Transform
+      pos: -2.5,20.5
+      parent: 1
+  - uid: 1551
+    components:
+    - type: Transform
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 1552
+    components:
+    - type: Transform
+      pos: -2.5,18.5
+      parent: 1
 - proto: CableHV
   entities:
-  - uid: 137
-    components:
-    - type: Transform
-      pos: -1.5,10.5
-      parent: 1
-  - uid: 138
-    components:
-    - type: Transform
-      pos: -1.5,14.5
-      parent: 1
-  - uid: 139
-    components:
-    - type: Transform
-      pos: -1.5,9.5
-      parent: 1
-  - uid: 140
-    components:
-    - type: Transform
-      pos: -1.5,11.5
-      parent: 1
-  - uid: 141
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 1
-  - uid: 142
-    components:
-    - type: Transform
-      pos: -1.5,12.5
-      parent: 1
   - uid: 143
     components:
     - type: Transform
-      pos: -1.5,15.5
-      parent: 1
-  - uid: 144
-    components:
-    - type: Transform
-      pos: -0.5,16.5
+      pos: -1.5,25.5
       parent: 1
   - uid: 145
     components:
     - type: Transform
-      pos: 0.5,9.5
-      parent: 1
-  - uid: 146
-    components:
-    - type: Transform
-      pos: -1.5,16.5
+      pos: 2.5,24.5
       parent: 1
   - uid: 147
     components:
     - type: Transform
-      pos: 2.5,9.5
+      pos: 2.5,21.5
       parent: 1
   - uid: 148
     components:
     - type: Transform
-      pos: 6.5,9.5
+      pos: 2.5,22.5
       parent: 1
   - uid: 149
     components:
     - type: Transform
-      pos: 4.5,9.5
+      pos: 2.5,23.5
       parent: 1
   - uid: 150
     components:
     - type: Transform
-      pos: 6.5,15.5
+      pos: 2.5,25.5
       parent: 1
   - uid: 151
     components:
     - type: Transform
-      pos: 6.5,13.5
+      pos: 4.5,24.5
       parent: 1
   - uid: 152
     components:
     - type: Transform
-      pos: 6.5,12.5
+      pos: 4.5,23.5
       parent: 1
   - uid: 153
     components:
     - type: Transform
-      pos: 6.5,11.5
+      pos: 4.5,25.5
       parent: 1
   - uid: 154
     components:
     - type: Transform
-      pos: 6.5,10.5
+      pos: 4.5,22.5
       parent: 1
   - uid: 155
     components:
     - type: Transform
-      pos: 6.5,14.5
-      parent: 1
-  - uid: 156
-    components:
-    - type: Transform
-      pos: 4.5,10.5
-      parent: 1
-  - uid: 157
-    components:
-    - type: Transform
-      pos: 4.5,11.5
-      parent: 1
-  - uid: 158
-    components:
-    - type: Transform
-      pos: 4.5,12.5
-      parent: 1
-  - uid: 159
-    components:
-    - type: Transform
-      pos: 4.5,13.5
-      parent: 1
-  - uid: 160
-    components:
-    - type: Transform
-      pos: 4.5,15.5
-      parent: 1
-  - uid: 161
-    components:
-    - type: Transform
-      pos: 4.5,14.5
-      parent: 1
-  - uid: 162
-    components:
-    - type: Transform
-      pos: 2.5,14.5
-      parent: 1
-  - uid: 163
-    components:
-    - type: Transform
-      pos: 2.5,13.5
-      parent: 1
-  - uid: 164
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 165
-    components:
-    - type: Transform
-      pos: 2.5,11.5
-      parent: 1
-  - uid: 166
-    components:
-    - type: Transform
-      pos: 2.5,15.5
-      parent: 1
-  - uid: 167
-    components:
-    - type: Transform
-      pos: 2.5,10.5
-      parent: 1
-  - uid: 168
-    components:
-    - type: Transform
-      pos: 0.5,10.5
-      parent: 1
-  - uid: 169
-    components:
-    - type: Transform
-      pos: 0.5,13.5
-      parent: 1
-  - uid: 170
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 1
-  - uid: 171
-    components:
-    - type: Transform
-      pos: 0.5,14.5
-      parent: 1
-  - uid: 172
-    components:
-    - type: Transform
-      pos: 0.5,15.5
-      parent: 1
-  - uid: 173
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 1
-  - uid: 174
-    components:
-    - type: Transform
-      pos: 2.5,16.5
-      parent: 1
-  - uid: 175
-    components:
-    - type: Transform
-      pos: 6.5,16.5
+      pos: 4.5,21.5
       parent: 1
   - uid: 176
     components:
@@ -3198,30 +3105,175 @@ entities:
     - type: Transform
       pos: 17.5,9.5
       parent: 1
-  - uid: 198
+  - uid: 356
     components:
     - type: Transform
-      pos: 4.5,16.5
+      pos: -1.5,19.5
       parent: 1
-  - uid: 199
+  - uid: 357
     components:
     - type: Transform
-      pos: 3.5,16.5
+      pos: -1.5,20.5
       parent: 1
-  - uid: 200
+  - uid: 358
     components:
     - type: Transform
-      pos: 1.5,16.5
+      pos: -1.5,21.5
       parent: 1
-  - uid: 201
+  - uid: 359
     components:
     - type: Transform
-      pos: 0.5,16.5
+      pos: -1.5,22.5
       parent: 1
-  - uid: 202
+  - uid: 360
     components:
     - type: Transform
-      pos: 5.5,16.5
+      pos: -1.5,23.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -1.5,24.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 6.5,24.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 2.5,18.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 6.5,23.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 6.5,20.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 6.5,22.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 6.5,25.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      pos: 0.5,25.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      pos: 0.5,24.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 0.5,21.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      pos: 0.5,23.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -1.5,18.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      pos: 0.5,22.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 1554
+    components:
+    - type: Transform
+      pos: 1.5,18.5
+      parent: 1
+  - uid: 1555
+    components:
+    - type: Transform
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 1556
+    components:
+    - type: Transform
+      pos: 5.5,18.5
       parent: 1
 - proto: CableMV
   entities:
@@ -4254,6 +4306,84 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,25.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,24.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,25.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,24.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,23.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,20.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,22.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,21.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,25.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,21.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,20.5
+      parent: 1
   - uid: 315
     components:
     - type: Transform
@@ -4407,116 +4537,68 @@ entities:
   - uid: 345
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,20.5
       parent: 1
   - uid: 346
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,19.5
       parent: 1
   - uid: 347
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,13.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,25.5
       parent: 1
   - uid: 348
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,12.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,23.5
       parent: 1
   - uid: 349
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,11.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,24.5
       parent: 1
   - uid: 350
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,22.5
       parent: 1
   - uid: 351
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,19.5
       parent: 1
   - uid: 352
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,24.5
       parent: 1
   - uid: 353
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,23.5
       parent: 1
   - uid: 354
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,21.5
       parent: 1
   - uid: 355
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,9.5
-      parent: 1
-  - uid: 356
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,10.5
-      parent: 1
-  - uid: 357
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,11.5
-      parent: 1
-  - uid: 358
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,12.5
-      parent: 1
-  - uid: 359
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,13.5
-      parent: 1
-  - uid: 360
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,14.5
-      parent: 1
-  - uid: 361
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,15.5
-      parent: 1
-  - uid: 362
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,16.5
-      parent: 1
-  - uid: 363
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,22.5
       parent: 1
   - uid: 364
     components:
@@ -4530,161 +4612,131 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 9.5,16.5
       parent: 1
-  - uid: 366
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,10.5
-      parent: 1
-  - uid: 367
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,11.5
-      parent: 1
   - uid: 368
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,12.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,20.5
       parent: 1
   - uid: 369
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,13.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,21.5
       parent: 1
   - uid: 370
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,22.5
       parent: 1
   - uid: 371
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,17.5
       parent: 1
   - uid: 372
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,18.5
       parent: 1
   - uid: 373
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,11.5
-      parent: 1
-  - uid: 374
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,12.5
-      parent: 1
-  - uid: 375
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,13.5
-      parent: 1
-  - uid: 376
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,14.5
-      parent: 1
-  - uid: 377
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,19.5
       parent: 1
   - uid: 378
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,16.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,19.5
       parent: 1
   - uid: 379
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,10.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,21.5
       parent: 1
   - uid: 380
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,11.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,23.5
       parent: 1
   - uid: 381
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,12.5
-      parent: 1
-  - uid: 382
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,13.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,24.5
       parent: 1
   - uid: 383
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,25.5
       parent: 1
   - uid: 384
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 5.5,18.5
       parent: 1
   - uid: 385
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,18.5
       parent: 1
   - uid: 386
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 3.5,18.5
       parent: 1
   - uid: 387
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,16.5
-      parent: 1
-  - uid: 388
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,16.5
-      parent: 1
-  - uid: 389
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,18.5
       parent: 1
   - uid: 390
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,18.5
       parent: 1
   - uid: 391
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,16.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,22.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,23.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,16.5
       parent: 1
 - proto: Chair
   entities:
@@ -5376,180 +5428,81 @@ entities:
       parent: 1
 - proto: FenceMetalCorner
   entities:
-  - uid: 436
-    components:
-    - type: Transform
-      pos: 7.5,8.5
-      parent: 1
-  - uid: 437
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,8.5
-      parent: 1
   - uid: 438
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,17.5
       parent: 1
-  - uid: 439
+  - uid: 471
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,13.5
+      pos: 5.5,14.5
       parent: 1
-- proto: FenceMetalGate
-  entities:
-  - uid: 440
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,13.5
-      parent: 1
-- proto: FenceMetalStraight
-  entities:
-  - uid: 441
-    components:
-    - type: Transform
-      pos: -2.5,9.5
-      parent: 1
-  - uid: 442
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,8.5
-      parent: 1
-  - uid: 443
+  - uid: 897
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,8.5
+      pos: 5.5,17.5
       parent: 1
-  - uid: 444
+  - uid: 910
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,8.5
+      pos: 7.5,20.5
       parent: 1
-  - uid: 445
+  - uid: 926
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: 7.5,26.5
       parent: 1
-  - uid: 446
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,8.5
-      parent: 1
-  - uid: 447
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,8.5
-      parent: 1
-  - uid: 448
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,8.5
-      parent: 1
-  - uid: 449
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,8.5
-      parent: 1
-  - uid: 450
+  - uid: 927
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,10.5
+      pos: -2.5,26.5
       parent: 1
-  - uid: 451
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,17.5
-      parent: 1
-  - uid: 452
+- proto: FenceMetalGate
+  entities:
+  - uid: 168
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,12.5
+      pos: 9.5,14.5
       parent: 1
-  - uid: 453
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,17.5
-      parent: 1
-  - uid: 454
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,13.5
-      parent: 1
-  - uid: 455
+- proto: FenceMetalStraight
+  entities:
+  - uid: 156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 7.5,11.5
+      pos: 5.5,16.5
       parent: 1
-  - uid: 456
+  - uid: 157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,10.5
+      pos: 5.5,15.5
       parent: 1
-  - uid: 457
+  - uid: 163
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,11.5
+      rot: 1.5707963267948966 rad
+      pos: 8.5,14.5
       parent: 1
-  - uid: 458
+  - uid: 164
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,12.5
+      rot: 1.5707963267948966 rad
+      pos: 7.5,14.5
       parent: 1
-  - uid: 459
+  - uid: 169
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,13.5
-      parent: 1
-  - uid: 460
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,14.5
-      parent: 1
-  - uid: 461
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,15.5
-      parent: 1
-  - uid: 462
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,16.5
-      parent: 1
-  - uid: 463
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,17.5
-      parent: 1
-  - uid: 464
-    components:
-    - type: Transform
-      pos: 7.5,9.5
+      rot: 1.5707963267948966 rad
+      pos: 6.5,14.5
       parent: 1
   - uid: 465
     components:
@@ -5587,29 +5540,143 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,17.5
       parent: 1
-  - uid: 471
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,17.5
-      parent: 1
-  - uid: 472
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,17.5
-      parent: 1
   - uid: 473
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,17.5
       parent: 1
-  - uid: 474
+  - uid: 913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,21.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,22.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,23.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,24.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,25.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,25.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,24.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,23.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,22.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,20.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,18.5
+      parent: 1
+  - uid: 928
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,8.5
+      pos: -1.5,26.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,26.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,26.5
+      parent: 1
+  - uid: 1370
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,26.5
+      parent: 1
+  - uid: 1380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,26.5
+      parent: 1
+  - uid: 1381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,26.5
+      parent: 1
+  - uid: 1382
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,26.5
+      parent: 1
+  - uid: 1383
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,26.5
+      parent: 1
+  - uid: 1384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,26.5
       parent: 1
 - proto: filingCabinetTallRandom
   entities:
@@ -6200,7 +6267,7 @@ entities:
       pos: -3.5,-5.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -19036.762
+      secondsUntilStateChange: -20577.93
       state: Opening
   - uid: 549
     components:
@@ -8359,6 +8426,46 @@ entities:
     - type: Transform
       pos: -12.5,-7.5
       parent: 1
+- proto: PartRodMetal1
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.4023323,19.546394
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.6002488,18.71306
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.20267916,18.617575
+      parent: 1
+  - uid: 1553
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5047624,18.626255
+      parent: 1
+- proto: Pickaxe
+  entities:
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.337175,12.772261
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.514259,13.126428
+      parent: 1
 - proto: PlushieRedFox
   entities:
   - uid: 848
@@ -8611,6 +8718,12 @@ entities:
       parent: 1
 - proto: PoweredLightPostSmall
   entities:
+  - uid: 159
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 1
   - uid: 1112
     components:
     - type: Transform
@@ -8664,12 +8777,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 15.5,6.5
-      parent: 1
-  - uid: 1423
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,12.5
       parent: 1
 - proto: RadarConsoleCircuitboard
   entities:
@@ -8892,41 +8999,54 @@ entities:
       parent: 1
 - proto: ShardGlass
   entities:
-  - uid: 878
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.2103815,15.564493
-      parent: 1
-  - uid: 879
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.6548262,15.633938
-      parent: 1
-  - uid: 880
+  - uid: 366
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5562761,10.090061
+      pos: 3.0636716,24.376451
       parent: 1
-  - uid: 881
+  - uid: 367
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.7646096,10.550132
+      pos: 5.2386713,21.241451
       parent: 1
-  - uid: 882
+  - uid: 388
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 3.3308766,12.312284
+      pos: 5.9586716,22.666452
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.166688,24.451376
       parent: 1
   - uid: 883
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.3152514,12.390409
+      pos: -1.479188,24.36357
+      parent: 1
+- proto: SheetPlastic10
+  entities:
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -15.305927,12.449344
+      parent: 1
+- proto: Shovel
+  entities:
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -13.108009,15.709761
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -12.545509,15.543095
       parent: 1
 - proto: ShuttersNormal
   entities:
@@ -8996,20 +9116,50 @@ entities:
       parent: 1
 - proto: SolarAssembly
   entities:
-  - uid: 896
+  - uid: 362
     components:
     - type: Transform
-      pos: 2.5,12.5
+      pos: 2.5,19.5
       parent: 1
-  - uid: 897
+  - uid: 363
     components:
     - type: Transform
-      pos: -1.5,10.5
+      pos: 2.5,21.5
       parent: 1
-  - uid: 898
+  - uid: 382
     components:
     - type: Transform
-      pos: 2.5,15.5
+      pos: 2.5,24.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 6.5,22.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 4.5,22.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 4.5,25.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 4.5,21.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      pos: -1.5,24.5
       parent: 1
 - proto: SolarControlComputerCircuitboard
   entities:
@@ -9020,204 +9170,164 @@ entities:
       parent: 1
 - proto: SolarPanel
   entities:
-  - uid: 899
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,15.5
+      pos: -1.5,19.5
       parent: 1
-  - uid: 900
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,13.5
+      pos: -1.5,21.5
       parent: 1
-  - uid: 901
+  - uid: 142
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,12.5
+      pos: 0.5,20.5
       parent: 1
-  - uid: 902
+  - uid: 144
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,11.5
+      pos: 0.5,19.5
       parent: 1
-  - uid: 903
+  - uid: 146
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -1.5,9.5
+      pos: -1.5,22.5
       parent: 1
-  - uid: 904
+  - uid: 374
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,9.5
+      pos: 4.5,23.5
       parent: 1
-  - uid: 905
+  - uid: 375
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,11.5
+      pos: 6.5,21.5
       parent: 1
-  - uid: 906
+  - uid: 376
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,12.5
+      pos: 4.5,20.5
       parent: 1
-  - uid: 907
+  - uid: 445
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,14.5
+      pos: 6.5,20.5
       parent: 1
-  - uid: 908
+  - uid: 446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,15.5
+      pos: 6.5,24.5
       parent: 1
-  - uid: 909
+  - uid: 462
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,11.5
+      pos: 2.5,22.5
       parent: 1
-  - uid: 910
+  - uid: 464
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,13.5
+      pos: 0.5,22.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,23.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,25.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,23.5
       parent: 1
   - uid: 911
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,10.5
-      parent: 1
-  - uid: 912
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,9.5
-      parent: 1
-  - uid: 913
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,11.5
-      parent: 1
-  - uid: 914
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,13.5
-      parent: 1
-  - uid: 915
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,14.5
-      parent: 1
-  - uid: 916
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,12.5
-      parent: 1
-  - uid: 917
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,10.5
-      parent: 1
-  - uid: 918
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,14.5
-      parent: 1
-  - uid: 919
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,13.5
-      parent: 1
-  - uid: 920
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,12.5
+      pos: 0.5,23.5
       parent: 1
 - proto: SolarPanelBroken
   entities:
-  - uid: 921
+  - uid: 138
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,11.5
+      rot: 3.141592653589793 rad
+      pos: -1.5,20.5
       parent: 1
-  - uid: 922
+  - uid: 139
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,21.5
       parent: 1
-  - uid: 923
+  - uid: 1557
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,25.5
       parent: 1
-  - uid: 924
+  - uid: 1558
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,13.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,24.5
       parent: 1
-  - uid: 925
+  - uid: 1559
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,25.5
       parent: 1
-  - uid: 926
+  - uid: 1560
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,20.5
       parent: 1
-  - uid: 927
+  - uid: 1561
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,10.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,19.5
       parent: 1
-  - uid: 928
+  - uid: 1562
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,9.5
+      rot: 3.141592653589793 rad
+      pos: 4.5,24.5
       parent: 1
-  - uid: 929
+  - uid: 1563
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,14.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,25.5
       parent: 1
-- proto: SolarTrackerElectronics
-  entities:
-  - uid: 930
+  - uid: 1564
     components:
     - type: Transform
-      pos: 2.5843492,15.593534
+      rot: 3.141592653589793 rad
+      pos: 6.5,23.5
       parent: 1
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
 - proto: SophicScribeSpawner
   entities:
   - uid: 931


### PR DESCRIPTION
<img width="1204" height="877" alt="image" src="https://github.com/user-attachments/assets/78e7c787-bcd0-401f-8341-ce5a2b9d0e94" />


# Changelog
:cl:
- tweak: Tradepost now includes some round-start mining tools, and its solar panel array is not located further north.