### PR TITLE
Fix the Hop Collar Not Being in the Hop Loadout

### DIFF
--- a/Resources/Prototypes/_Vulp/Entities/Neck/collars.yml
+++ b/Resources/Prototypes/_Vulp/Entities/Neck/collars.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   parent: ClothingNeckBase
   id: ClothingNeckCollarHop
-  name: head of personal collar
+  name: head of personnel collar
   description: The Head of Personnel's Collar, a thin red stripe runs along the centre with a small piece of bright red ruby in the middle of the silver and gold tag, shimmering in the light, the inside of the collar is lined with high quality felt, soft to the touch to be sure its comfortable for the wearer while they're hunched over their desk with a head buried in paperwork
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Vulp/Loadouts/neck.yml
+++ b/Resources/Prototypes/_Vulp/Loadouts/neck.yml
@@ -1,7 +1,7 @@
 ﻿# Collars
 - type: loadout
   id: LoadoutCommandHopCollar
-  category: JobsCommand
+  category: JobsCommandHeadOfPersonnel
   cost: 1
   requirements:
   - !type:CharacterJobRequirement


### PR DESCRIPTION

Description.

Fixed HOP collar being under the wrong loadout category, it will now be under the Head of Personnel section and not in your way while working on loadouts.

---

# Changelog

:cl:
- fix: Fixed HOP collar being under the wrong loadout category, it will now be under the Head of Personnel section and not in your way while working on loadouts.

