### PR TITLE
Rnd console exploit 2

### DIFF
--- a/Content.Server/Research/Systems/ResearchSystem.Console.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Console.cs
@@ -70,10 +70,11 @@ public sealed partial class ResearchSystem
 
         ResearchConsoleBoundInterfaceState state;
 
-        if (TryGetClientServer(uid, out _, out var serverComponent, clientComponent))
+        if (TryGetClientServer(uid, out var serverUid, out var serverComponent, clientComponent))
         {
-            var points = clientComponent.ConnectedToServer ? serverComponent.Points : 0;
-            var softCap = clientComponent.ConnectedToServer ? serverComponent.CurrentSoftCapMultiplier : 1;
+            // Floofstation - use tech DB. Also, this condition succeeding implies ConnectedToServer
+            var points = serverComponent.Points;
+            var softCap = CompOrNull<TechnologyDatabaseComponent>(serverUid)?.SoftCapMultiplier ?? 1;
             state = new ResearchConsoleBoundInterfaceState(points, softCap);
         }
         else

--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -47,7 +47,8 @@ public sealed partial class ResearchSystem
             return;
 
         technologyDatabase.SoftCapMultiplier = record.SoftCapMultiplier;
-        ent.Comp.CurrentSoftCapMultiplier = record.SoftCapMultiplier;
+        // Floofstation - removed
+        // ent.Comp.CurrentSoftCapMultiplier = record.SoftCapMultiplier;
     }
     // TheDen section end
 

--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -83,7 +83,7 @@ public sealed partial class ResearchSystem
 
         // The den section start
         var station = _station.GetOwningStation(client);
-        var oldSoftCap = clientDatabase.SoftCapMultiplier;
+        var oldSoftCap = serverDatabase.SoftCapMultiplier; // Floofstation - server is authoritative
         // The den section end
 
         if (prototype.Tier >= disciplinePrototype.LockoutTier)

--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -78,7 +78,7 @@ public sealed partial class ResearchSystem
             || !PrototypeManager.TryIndex(prototype.Discipline, out var disciplinePrototype)
             || !TryComp<ResearchServerComponent>(serverEnt.Value, out var researchServer)
             || !TryComp<TechnologyDatabaseComponent>(serverEnt.Value, out var serverDatabase) // Floofstation
-            || prototype.Cost * clientDatabase.SoftCapMultiplier > researchServer.Points)
+            || prototype.Cost * serverDatabase.SoftCapMultiplier > researchServer.Points)
             return false;
 
         // The den section start
@@ -98,7 +98,7 @@ public sealed partial class ResearchSystem
             && Exists(station)
             && station != EntityUid.Invalid
             && TryComp<StationResearchRecordComponent>(station, out var record))
-            record.SoftCapMultiplier = MathF.Max(clientDatabase.SoftCapMultiplier, record.SoftCapMultiplier); // Floofstation - use max here
+            record.SoftCapMultiplier = MathF.Max(serverDatabase.SoftCapMultiplier, record.SoftCapMultiplier); // Floofstation - use max here
 
         AddTechnology(serverEnt.Value, prototype);
         TrySetMainDiscipline(prototype, serverEnt.Value);

--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -77,6 +77,7 @@ public sealed partial class ResearchSystem
             || !CanServerUnlockTechnology(client, prototype, clientDatabase, component)
             || !PrototypeManager.TryIndex(prototype.Discipline, out var disciplinePrototype)
             || !TryComp<ResearchServerComponent>(serverEnt.Value, out var researchServer)
+            || !TryComp<TechnologyDatabaseComponent>(serverEnt.Value, out var serverDatabase) // Floofstation
             || prototype.Cost * clientDatabase.SoftCapMultiplier > researchServer.Points)
             return false;
 
@@ -87,8 +88,9 @@ public sealed partial class ResearchSystem
 
         if (prototype.Tier >= disciplinePrototype.LockoutTier)
         {
-            clientDatabase.SoftCapMultiplier *= prototype.SoftCapContribution;
-            researchServer.CurrentSoftCapMultiplier *= prototype.SoftCapContribution;
+            // Floofstation - server is authoritative
+            serverDatabase.SoftCapMultiplier *= prototype.SoftCapContribution;
+            clientDatabase.SoftCapMultiplier = serverDatabase.SoftCapMultiplier;
         }
 
         // TheDen edit
@@ -96,7 +98,7 @@ public sealed partial class ResearchSystem
             && Exists(station)
             && station != EntityUid.Invalid
             && TryComp<StationResearchRecordComponent>(station, out var record))
-            record.SoftCapMultiplier = clientDatabase.SoftCapMultiplier;
+            record.SoftCapMultiplier = MathF.Max(clientDatabase.SoftCapMultiplier, record.SoftCapMultiplier); // Floofstation - use max here
 
         AddTechnology(serverEnt.Value, prototype);
         TrySetMainDiscipline(prototype, serverEnt.Value);

--- a/Content.Shared/Research/Components/ResearchServerComponent.cs
+++ b/Content.Shared/Research/Components/ResearchServerComponent.cs
@@ -43,8 +43,9 @@ public sealed partial class ResearchServerComponent : Component
     [DataField("researchConsoleUpdateTime"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan ResearchConsoleUpdateTime = TimeSpan.FromSeconds(1);
 
-    [DataField, AutoNetworkedField]
-    public float CurrentSoftCapMultiplier = 1;
+    // Floofstation - WHYYYY
+    // [DataField, AutoNetworkedField]
+    // public float CurrentSoftCapMultiplier = 1;
 }
 
 /// <summary>


### PR DESCRIPTION
https://github.com/Floof-Station/Floof-Station/pull/1403/

# Description
Turns out the research cost multiplier is tracked independently in three different components across FOUR (???) different places! I don't have any nice words for this anymore.

This completely obliterates ResearcServerComponent.CurrentSoftCapMultiplier in favor of TechnologyDatabase.SoftCapMultiplier. The latter was preferred because it's shared across the server and its clients. Also, when saving the research cost multiplier station-wide, the greatest of the [station multiplier, server multiplier] is preferred

Also fixes another exploit - you could build two servers, only research tier 3 on one of them, then research something on server 2 (resetting the console's softcap multiplier), then switch back to server 1 and research anything with a 1x softcap multiplier (because EE thought it's a good idea to make clients authoritative for some reason)

# Test cases
- [X] Softcap multiplier applies to research cost
- [X] It is preserved across consoles and servers
- [X] It correctly applies when there are multiple servers or clients

<details><summary><h1>Media</h1></summary>
<p>

https://github.com/user-attachments/assets/a4b99cc6-9140-4baf-b511-55792edf1020


</p>
</details>

# Changelog
No cl