### PR TITLE
Grid merge preserves decals + new gridmerge command

### DIFF
--- a/Content.Server/Decals/DecalSystem.cs
+++ b/Content.Server/Decals/DecalSystem.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -367,6 +368,23 @@ namespace Content.Server.Decals
 
             return decalIds;
         }
+
+        // Vulpstation section
+        public IEnumerable<(Vector2i, Decal)> GetAllDecals(EntityUid gridUid, DecalGridComponent? component = null)
+        {
+            var chunkCollection = ChunkCollection(gridUid, component);
+            if (chunkCollection == null)
+                yield break;
+
+            foreach (var (chunkIdx, decalChunk) in chunkCollection)
+            {
+                foreach (var (id, decal) in decalChunk.Decals)
+                {
+                    yield return (chunkIdx, decal);
+                }
+            }
+        }
+        // Vulpstation section end
 
         /// <summary>
         ///     Changes a decals position. Note this will actually result in a new decal being created, possibly on a new grid or chunk.

--- a/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.GridMerging.cs
+++ b/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.GridMerging.cs
@@ -1,0 +1,111 @@
+using System.Numerics;
+using Content.Server.Administration;
+using Content.Server.Decals;
+using Content.Shared.Administration;
+using Content.Shared.Decals;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Toolshed;
+
+
+namespace Content.Server._Vulp.Station.Systems;
+
+
+public sealed partial class PlanetStationSystem
+{
+    [Dependency] private readonly DecalSystem _decals = default!;
+
+    /// <summary>
+    ///     Tries to merge source into target.
+    /// </summary>
+    public void MergeGrids(EntityUid target, EntityUid source)
+    {
+        if (!TryComp<MapGridComponent>(source, out var sourceGrid) || !TryComp<MapGridComponent>(target, out var targetGrid))
+            return;
+
+        var original = _xforms.GetWorldPositionRotation(Transform(source));
+        // Round position and rotation
+        _xforms.SetWorldPositionRotation(
+            source,
+            original.WorldPosition.Rounded(),
+            original.WorldRotation.GetCardinalDir().ToAngle());
+
+        var sourceMat = _xforms.GetWorldMatrix(source);
+        var targetInvMat = _xforms.GetInvWorldMatrix(target);
+
+        // GridFixtureSystem fails to transfer unanchored entities
+        // Faster to do an all-entity query rather than use entity lookup
+        var query = AllEntityQuery<TransformComponent>();
+        var detachedEntities = new List<(EntityUid uid, Vector2 worldPos, Angle worldRot)>();
+        while (query.MoveNext(out var uid, out var xform))
+        {
+            // Only entities on this grid that are directly parented to it (not in containers)
+            // Also ignore anchored entities because those will be processed by the grid fixture system
+            if (xform.GridUid != source || xform.ParentUid != source || xform.Anchored || MetaData(uid).Flags.HasFlag(MetaDataFlags.InContainer))
+                continue;
+
+            // ???
+            if (HasComp<MapGridComponent>(uid))
+                continue;
+
+            // TODO change this to use the cached transform matrices
+            var (position, rotation) = _xforms.GetWorldPositionRotation(xform);
+            _xforms.DetachEntity(uid, xform);
+            detachedEntities.Add((uid, position, rotation));
+        }
+
+        // Save decals. This is necessary because the target grid may lack the tiles to put them on at this point.
+        var savedDecals = new List<(Vector2i pos, Decal decal)>();
+        foreach (var (idx, decal) in _decals.GetAllDecals(source))
+            savedDecals.Add((idx, decal));
+
+        // Actually do the merge. This will prepare the tiles on the target grid and delete the source grid
+        _gridFixtures.Merge(target, source, Transform(source).LocalMatrix);
+
+        // Move saved entities over
+        foreach (var entity in detachedEntities)
+        {
+            _xforms.SetParent(entity.uid, target);
+            _xforms.SetWorldPositionRotation(entity.uid, entity.worldPos, entity.worldRot);
+        }
+
+        // Copy saved decals
+        foreach (var (idx, decal) in savedDecals)
+        {
+            var decalCoords = Vector2.Transform(Vector2.Transform(decal.Coordinates, sourceMat), targetInvMat);
+            var resultEntCoords = new EntityCoordinates(target, decalCoords);
+            _decals.TryAddDecal(decal.WithCoordinates(decalCoords), resultEntCoords, out _);
+        }
+    }
+}
+
+[ToolshedCommand, AdminCommand(AdminFlags.Admin)]
+public sealed class MergeGridCommand : ToolshedCommand
+{
+    [CommandImplementation("into")]
+    public void MergeSafe(
+        IInvocationContext ctx,
+        [PipedArgument] EntityUid gridUid,
+        [CommandArgument] EntityUid target)
+    {
+        if (Transform(target).MapUid != target)
+            throw new ArgumentException("The target grid is not a map! Use into_UNSAFE to override safety. This might cause bugs or even crash the game if you aren't careful!");
+
+        MergeUnsafe(ctx, gridUid, target);
+    }
+
+    [CommandImplementation("into_UNSAFE")]
+    public void MergeUnsafe(
+        IInvocationContext ctx,
+        [PipedArgument] EntityUid gridUid,
+        [CommandArgument] EntityUid target)
+    {
+        if (!TryComp(gridUid, out MapGridComponent? grid))
+            throw new ArgumentException("Piped argument (source grid) is not a grid");
+
+        if (!TryComp(target, out MapGridComponent? targetGrid))
+            throw new ArgumentException("First argument (target grid) is not a grid");
+
+        EntityManager.System<PlanetStationSystem>().MergeGrids(target, gridUid);
+    }
+}

--- a/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.cs
+++ b/Content.Server/_Vulp/Station/Systems/PlanetStationSystem.cs
@@ -1,15 +1,11 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using Content.Server._Vulp.Station.Components;
 using Content.Server.Atmos.Components;
 using Content.Server.Parallax;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Systems;
-using Content.Server.Spawners.Components;
 using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Server.Station.Systems;
-using Content.Shared._NC14.DayNightCycle;
 using Content.Shared.Dataset;
 using Content.Shared.Destructible.Thresholds;
 using Content.Shared.Parallax.Biomes;
@@ -17,7 +13,6 @@ using Content.Shared.Procedural.Loot;
 using Robust.Server.GameObjects;
 using Robust.Server.Physics;
 using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -75,6 +70,7 @@ public sealed partial class PlanetStationSystem : EntitySystem
             return;
 
         // copypasted from PlanetCommand. go ahead sue me
+        // TODO make sure this isn't called if there are multiple planetstations on the same map
         foreach (var loot in _proto.EnumeratePrototypes<SalvageLootPrototype>())
         {
             if (!loot.Guaranteed)
@@ -113,47 +109,6 @@ public sealed partial class PlanetStationSystem : EntitySystem
                 Log.Error("FTL time is set, but merge into planet is enabled. This is not possible, skipping map merge.");
             else
                 MergeGrids(mapUid, stationGrid.Value);
-        }
-    }
-
-    /// <summary>
-    ///     Tries to merge source into target.
-    /// </summary>
-    public void MergeGrids(EntityUid target, EntityUid source)
-    {
-        var original = _xforms.GetWorldPositionRotation(Transform(source));
-        // Round position and rotation
-        _xforms.SetWorldPositionRotation(
-            source,
-            original.WorldPosition.Rounded(),
-            original.WorldRotation.GetCardinalDir().ToAngle());
-
-        // GridFixtureSystem fails to transfer unanchored entities
-        // Faster to do an all-entity query rather than use entity lookup
-        var query = AllEntityQuery<TransformComponent>();
-        var detachedEntities = new List<(EntityUid uid, Vector2 worldPos, Angle worldRot)>();
-        while (query.MoveNext(out var uid, out var xform))
-        {
-            // Only entities on this grid that are directly parented to it (not in containers)
-            // Also ignore anchored entities because those will be processed by the grid fixture system
-            if (xform.GridUid != source || xform.ParentUid != source || xform.Anchored || MetaData(uid).Flags.HasFlag(MetaDataFlags.InContainer))
-                continue;
-
-            // ???
-            if (HasComp<MapGridComponent>(uid))
-                continue;
-
-            var (position, rotation) = _xforms.GetWorldPositionRotation(xform);
-            _xforms.DetachEntity(uid, xform);
-            detachedEntities.Add((uid, position, rotation));
-        }
-
-        _gridFixtures.Merge(target, source, Transform(source).LocalMatrix);
-
-        foreach (var entity in detachedEntities)
-        {
-            _xforms.SetParent(entity.uid, target);
-            _xforms.SetWorldPositionRotation(entity.uid, entity.worldPos, entity.worldRot);
         }
     }
 

--- a/Resources/Locale/en-US/_Vulp/station/planetstation.ftl
+++ b/Resources/Locale/en-US/_Vulp/station/planetstation.ftl
@@ -1,0 +1,5 @@
+command-description-mergegrid-into = Merge the source grid (piped argument) into the destination grid, preserving unanchored entities and decals.
+command-description-mergegrid-into_UNSAFE = UNSAFE version of mergegrid-into. Please make sure you are doing the right thing.
+
+command-help-mergegrid-into = Merge the source grid (piped argument) into the destination grid, preserving unanchored entities and decals.
+command-help-mergegrid-into_UNSAFE = UNSAFE version of mergegrid-into. Please make sure you are doing the right thing.


### PR DESCRIPTION
# Description
Yippie. The system still doesn't preserve atmos, but so long as no one maps a fridge without a freezer, or an atmos chamber, that should be fine.

<img width="593" height="352" alt="image" src="https://github.com/user-attachments/assets/f3eb8cab-f3b9-4d20-b425-b2516b75d38c" />

<img width="602" height="647" alt="image" src="https://github.com/user-attachments/assets/b3ff8050-4289-42b6-8f3f-6a1d79930a4d" />


# Changelog
:cl:
- fix: Grids will now have their decals preserved when they are merged into the planet.
- add: Added a mergegrid command toolshed for admins to use. Works the same as round-start grid merging.