### PR TITLE
(CW: Vore) Add Vore Component to More Entities

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -337,7 +337,7 @@
   id: MobCockroach
   description: This station is just crawling with bugs.
   components:
-  - type: Vore
+  - type: Vore # Vulpstation
   - type: Sprite
     drawdepth: SmallMobs
     sprite: Mobs/Animals/cockroach.rsi
@@ -468,7 +468,6 @@
   id: MobMothroach
   description: This is the adorable by-product of multiple attempts at genetically mixing mothpeople with cockroaches.
   components:
-  - type: Vore
   - type: GhostRole
     makeSentient: true
     allowSpeech: true
@@ -1923,7 +1922,7 @@
   id: MobLizard
   description: A harmless dragon.
   components:
-  - type: Vore
+  - type: Vore # Vulpstation
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 3

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -384,7 +384,7 @@
   name: snail
   description: Revolting unless you're french.
   components:
-  - type: Vore
+  - type: Vore # Vulpstation
   - type: Body
     prototype: Mouse
   - type: GhostRole
@@ -562,7 +562,6 @@
   id: MobSnailMoth
   name: Snoth
   components:
-  - type: Vore
   - type: Body
     prototype: Mothroach
   - type: GhostRole


### PR DESCRIPTION
# Description

It was suggested in the vulp discord that more of the (small) mobs should be able to be vore-devoured, whether for RP purposes or otherwise. I think it makes sense as you can already vore-devour mice in this manner, so why not similar critters? 

It was also mentioned that most mobs already have the vore component on them, but I didn't find this to be the case while looking. I'm not super familiar with the codebase yet (nor yaml, frankly) so I may have missed this. Given that the mouse mob has the vore component added directly within the prototype file, I simply did the same for other critters. (Lizard, snoth, snail, mothroach, cockroach.) 

I tested these changes and didn't run into any issues. 

---

# Changelog

:cl: Snowcat
- tweak: Added the vore component to various small critters (lizard, snoth, snail, mothroach, cockroach)

