### PR TITLE
Suggested Cargo Bounty Tweaks

### DIFF
--- a/Resources/Locale/en-US/_Vulp/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/_Vulp/cargo/bounties.ftl
@@ -1,0 +1,3 @@
+bounty-item-ghostsheet = Ghost sheet
+
+bounty-description-ghostsheet = BOO! CentComm is not nearly spooky enough. Ship us something spooky.

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -179,7 +179,7 @@
 
 - type: cargoBounty
   id: BountyHandcuffs
-  reward: 2500 # Vulp
+  reward: 1000
   description: bounty-description-handcuffs
   idPrefix: CC
   entries:
@@ -252,7 +252,7 @@
   idPrefix: CC
   entries:
   - name: bounty-item-monkey-cube
-    amount: 3
+    amount: 7 # Vulp - avoid arbitrage
     whitelist:
       tags:
       - MonkeyCube
@@ -425,16 +425,16 @@
       tags:
       - Toolbox
 
-- type: cargoBounty
-  id: BountyTrash
-  reward: 2000 # Vulp - reward colony for cleaning up a bit
-  description: bounty-description-trash
-  entries:
-  - name: bounty-item-trash
-    amount: 10
-    whitelist:
-      tags:
-      - Trash
+#- type: cargoBounty # Vulp - just going to remove this one for now
+#  id: BountyTrash
+#  reward: 1000 # Vulp
+#  description: bounty-description-trash
+#  entries:
+#  - name: bounty-item-trash
+#    amount: 10
+#    whitelist:
+#      tags:
+#      - Trash
 
 - type: cargoBounty
   id: BountyAnomalyCore

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -70,7 +70,7 @@
       - CarrotFries
 
 - type: cargoBounty
-  id: BountyCarp
+  id: BountyCarp # Vulp - seems rarely possible. requires expeditions or certain events i think.
   reward: 12500
   description: bounty-description-carp
   idPrefix: CC

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -69,17 +69,17 @@
       tags:
       - CarrotFries
 
-- type: cargoBounty
-  id: BountyCarp # Vulp - seems rarely possible. requires expeditions or certain events i think.
-  reward: 12500
-  description: bounty-description-carp
-  idPrefix: CC
-  entries:
-  - name: bounty-item-carp
-    amount: 1
-    whitelist:
-      tags:
-      - Carp
+#- type: cargoBounty # Vulp - rarely possible. may reenable if expeditions become a thing
+#  id: BountyCarp
+#  reward: 12500
+#  description: bounty-description-carp
+#  idPrefix: CC
+#  entries:
+#  - name: bounty-item-carp
+#    amount: 1
+#    whitelist:
+#      tags:
+#      - Carp
 
 - type: cargoBounty
   id: BountyClownCostume
@@ -119,17 +119,17 @@
       tags:
       - Crayon
 
-- type: cargoBounty
-  id: BountyCubanCarp # Vulp - food recipe that requires carp meat so same issue as other carp bounty
-  reward: 16000
-  description: bounty-description-cuban-carp
-  idPrefix: CC
-  entries:
-  - name: bounty-item-cuban-carp
-    amount: 1
-    whitelist:
-      tags:
-      - CubanCarp
+#- type: cargoBounty # Vulp - disabled for same reason as other carp bounty
+#  id: BountyCubanCarp
+#  reward: 16000
+#  description: bounty-description-cuban-carp
+#  idPrefix: CC
+#  entries:
+#  - name: bounty-item-cuban-carp
+#    amount: 1
+#    whitelist:
+#      tags:
+#      - CubanCarp
 
 - type: cargoBounty
   id: BountyDonut
@@ -179,7 +179,7 @@
 
 - type: cargoBounty
   id: BountyHandcuffs
-  reward: 2500 # Vulp - kinda annoying to craft (though easy) for such a tiny reward
+  reward: 2500 # Vulp
   description: bounty-description-handcuffs
   idPrefix: CC
   entries:
@@ -247,7 +247,7 @@
 
 - type: cargoBounty
   id: BountyMonkeyCube
-  reward: 3000 # Vulp - monkey cube crate costs 2k and nobody uses biofabricator
+  reward: 3000 # Vulp
   description: bounty-description-monkey-cube
   idPrefix: CC
   entries:
@@ -264,7 +264,7 @@
   idPrefix: SS13-
   entries:
   - name: bounty-item-mouse
-    amount: 5 # Vulp - good luck if theres even a single felinid awake
+    amount: 2 # Vulp - reward low enough to dissaude buying mouse crate for it. encourages mousetrap use or something
     whitelist:
       tags:
       - Mouse
@@ -293,7 +293,7 @@
 
 - type: cargoBounty
   id: BountyPercussion
-  reward: 15000 # Vulp - two percussion crates (5k) for 10k profit?
+  reward: 11500 # Vulp - some high profit arbitrage bounties are ok
   description: bounty-description-percussion
   entries:
   - name: bounty-item-percussion
@@ -328,19 +328,19 @@
       tags:
       - PrisonUniform
 
-- type: cargoBounty
-  id: BountyRadio
-  reward: 6500
-  description: bounty-description-radio
-  entries:
-  - name: bounty-item-radio
-    amount: 7 # Vulp - usually requires cargo smashing a ptech restock crate and i think that's not good. remove?
-    whitelist:
-      components:
-      - Headset
-      - RadioMicrophone
-      tags:
-      - Radio
+#- type: cargoBounty # Vulp - might just reduce the reward then make the required quantity one or two. removed for now.
+#  id: BountyRadio # Vulp - no more smashing ptech restocks!!
+#  reward: 6500
+#  description: bounty-description-radio
+#  entries:
+#  - name: bounty-item-radio
+#    amount: 7
+#    whitelist:
+#      components:
+#      - Headset
+#      - RadioMicrophone
+#      tags:
+#      - Radio
 
 - type: cargoBounty
   id: BountyShiv
@@ -389,7 +389,7 @@
 
 - type: cargoBounty
   id: BountySyringe
-  reward: 5000
+  reward: 4000 # Vulp
   description: bounty-description-syringe
   entries:
   - name: bounty-item-syringe
@@ -515,7 +515,7 @@
 
 - type: cargoBounty
   id: BountyLaserGun
-  reward: 28500 # Vulp - secfab prints practice laser rifles without research so maybe too high?
+  reward: 16500 # Vulp - still high reward, requires sec cooperation
   description: bounty-description-lasergun
   idPrefix: IV
   entries:
@@ -601,16 +601,16 @@
       components:
       - Skates
 
-- type: cargoBounty
-  id: BountyBedsheet # Vulp - this bounty is not possible on some maps and usually skipped. remove or add craft recipe?
-  reward: 4100
-  description: bounty-description-bedsheet
-  entries:
-  - name: bounty-item-bedsheet
-    amount: 3 # Vulp - i haven't looked but i remember having three bedsheets from medical beds so maybe this is better
-    whitelist:
-      tags:
-      - Bedsheet
+#- type: cargoBounty
+#  id: BountyBedsheet # Vulp - skipped 99% of the time. replaced with craftable "Ghost sheet" bounty
+#  reward: 4100
+#  description: bounty-description-bedsheet
+#  entries:
+#  - name: bounty-item-bedsheet
+#    amount: 3 # Vulp
+#    whitelist:
+#      tags:
+#      - Bedsheet
 
 - type: cargoBounty
   id: BountyBandana
@@ -692,7 +692,7 @@
 - type: cargoBounty
   id: BountyCardboardBox
   reward: 1500
-  description: bounty-description-cardobard-box
+  description: bounty-description-cardobard-box # nice typo
   entries:
   - name: bounty-item-cardboard-box
     amount: 12
@@ -712,7 +712,7 @@
       - Wine
 
 - type: cargoBounty
-  id: BountyCottonBoll # Vulp - people struggle with this one apparently. i think its fine
+  id: BountyCottonBoll
   reward: 8600
   description: bounty-description-cotton-boll
   entries:

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -256,6 +256,9 @@
     whitelist:
       tags:
       - MonkeyCube
+    blacklist:
+      tags:
+        - KoboldCube # Vulp - kobold cube uses monkey cube as parent
 
 - type: cargoBounty
   id: BountyMouse

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -120,7 +120,7 @@
       - Crayon
 
 - type: cargoBounty
-  id: BountyCubanCarp
+  id: BountyCubanCarp # Vulp - food recipe that requires carp meat so same issue as other carp bounty
   reward: 16000
   description: bounty-description-cuban-carp
   idPrefix: CC
@@ -179,7 +179,7 @@
 
 - type: cargoBounty
   id: BountyHandcuffs
-  reward: 1000
+  reward: 2500 # Vulp - kinda annoying to craft (though easy) for such a tiny reward
   description: bounty-description-handcuffs
   idPrefix: CC
   entries:
@@ -247,7 +247,7 @@
 
 - type: cargoBounty
   id: BountyMonkeyCube
-  reward: 2000
+  reward: 3000 # Vulp - monkey cube crate costs 2k and nobody uses biofabricator
   description: bounty-description-monkey-cube
   idPrefix: CC
   entries:
@@ -264,7 +264,7 @@
   idPrefix: SS13-
   entries:
   - name: bounty-item-mouse
-    amount: 5
+    amount: 5 # Vulp - good luck if theres even a single felinid awake
     whitelist:
       tags:
       - Mouse
@@ -275,7 +275,7 @@
   description: bounty-description-pancake
   entries:
   - name: bounty-item-pancake
-    amount: 13
+    amount: 12 # Vulp - twelve eggs in a carton, one per waffle
     whitelist:
       tags:
       - Pancake
@@ -293,7 +293,7 @@
 
 - type: cargoBounty
   id: BountyPercussion
-  reward: 15000
+  reward: 15000 # Vulp - two percussion crates (5k) for 10k profit?
   description: bounty-description-percussion
   entries:
   - name: bounty-item-percussion
@@ -334,7 +334,7 @@
   description: bounty-description-radio
   entries:
   - name: bounty-item-radio
-    amount: 7
+    amount: 7 # Vulp - usually requires cargo smashing a ptech restock crate and i think that's not good. remove?
     whitelist:
       components:
       - Headset
@@ -424,7 +424,7 @@
 
 - type: cargoBounty
   id: BountyTrash
-  reward: 500
+  reward: 2000 # Vulp - reward colony for cleaning up a bit
   description: bounty-description-trash
   entries:
   - name: bounty-item-trash
@@ -480,7 +480,7 @@
 
 - type: cargoBounty
   id: BountyLabeler
-  reward: 6660
+  reward: 3500 # Vulp - seems high considering 5 plastic cost, compared to other bounties
   description: bounty-description-labeler
   entries:
   - name: bounty-item-labeler
@@ -515,7 +515,7 @@
 
 - type: cargoBounty
   id: BountyLaserGun
-  reward: 28500
+  reward: 28500 # Vulp - secfab prints practice laser rifles without research so maybe too high?
   description: bounty-description-lasergun
   idPrefix: IV
   entries:
@@ -602,12 +602,12 @@
       - Skates
 
 - type: cargoBounty
-  id: BountyBedsheet
+  id: BountyBedsheet # Vulp - this bounty is not possible on some maps and usually skipped. remove or add craft recipe?
   reward: 4100
   description: bounty-description-bedsheet
   entries:
   - name: bounty-item-bedsheet
-    amount: 5
+    amount: 3 # Vulp - i haven't looked but i remember having three bedsheets from medical beds so maybe this is better
     whitelist:
       tags:
       - Bedsheet
@@ -712,7 +712,7 @@
       - Wine
 
 - type: cargoBounty
-  id: BountyCottonBoll
+  id: BountyCottonBoll # Vulp - people struggle with this one apparently. i think its fine
   reward: 8600
   description: bounty-description-cotton-boll
   entries:

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -74,7 +74,7 @@
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     state: advkit
   product: CrateEmergencyAdvancedKit
-  cost: 2000
+  cost: 3500 # Vulp - to stop bountyarbitragetest from yapping and seems too cheap anyway
   category: cargoproduct-category-name-medical
   group: market
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -287,6 +287,10 @@
     graph: GhostSheet
     node: ghost_sheet
   - type: IdentityBlocker
+  - type: Tag
+    tags:
+    - GhostSheet # Vulp
+    - WhitelistChameleon
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/monkeycube.yml
@@ -49,6 +49,9 @@
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: box_kobold
+  - type: Tag # Vulp
+    tags:
+    - KoboldCube
 
 - type: entity
   parent: MonkeyCubeBox
@@ -81,6 +84,9 @@
   - type: Sprite
     sprite: Objects/Misc/monkeycube.rsi
     state: wrapper_kobold
+  - type: Tag # Vulp
+    tags:
+    - KoboldCube
 
 - type: entity
   parent: MonkeyCubeBox

--- a/Resources/Prototypes/_Floof/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Bounties/bounties.yml
@@ -14,29 +14,29 @@
 
 - type: cargoBounty
   id: BountyDildo
-  reward: 2500
+  reward: 3500 # Vulp - 500 speso profit after two sextoy crates feels bad
   description: bounty-description-dildo
   entries:
   - name: bounty-item-dildo
-    amount: 8
+    amount: 8 # Vulp - 8 dildos??????
     whitelist:
       tags:
       - Dildo
 
 - type: cargoBounty
   id: BountyFleshlight
-  reward: 2000
+  reward: 3000 # Vulp - just increase the reward instead of reducing the amount needed, maybe?
   description: bounty-description-fleshlight
   entries:
   - name: bounty-item-fleshlight
-    amount: 5
+    amount: 3 # Vulp - reduce to 2 so one sextoy crate is enough, or 3 so one sextoy crate and one extra from a colonist's loadout?
     whitelist:
       tags:
       - Fleshlight
 
 - type: cargoBounty
   id: BountyPaddleWhip
-  reward: 1000
+  reward: 2800
   description: bounty-description-whip
   entries:
   - name: bounty-item-whip
@@ -103,7 +103,7 @@
 - type: cargoBounty
   id: BountyHanal
   reward: 3000
-  description: bounty-description-anal
+  description: bounty-description-anal # Vulp - lol
   entries:
   - name: bounty-item-anal
     amount: 5
@@ -135,7 +135,7 @@
 
 - type: cargoBounty
   id: BountyImplanter
-  reward: 750
+  reward: 2000 # Vulp - this reward is underwhelming even if the bounty is cheap/easy (15 steel 15 glass)
   description: bounty-description-implanter
   entries:
   - name: bounty-item-implanter
@@ -146,11 +146,11 @@
 
 - type: cargoBounty
   id: BountyBloodPacks
-  reward: 1300
+  reward: 2500
   description: bounty-description-bloodpack
   entries:
   - name: bounty-item-bloodpacks
-    amount: 5
+    amount: 5 # Vulp - actually annoying because nobody does the microwave recipe
     whitelist:
       tags:
       - Bloodpack
@@ -169,7 +169,7 @@
 
 - type: cargoBounty
   id: BountySurgeryTools
-  reward: 16000
+  reward: 9000 # Vulp - this one is so easy to do and most medical have surgery duffel in loadout
   description: bounty-description-surgerytools
   entries:
   - name: bounty-item-surgerydrill

--- a/Resources/Prototypes/_Floof/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Bounties/bounties.yml
@@ -40,7 +40,7 @@
   description: bounty-description-whip
   entries:
   - name: bounty-item-whip
-    amount: 3
+    amount: 3 # Vulp
     whitelist:
       tags:
       - Whip
@@ -135,11 +135,11 @@
 
 - type: cargoBounty
   id: BountyImplanter
-  reward: 2000 # Vulp - this reward is underwhelming even if the bounty is cheap/easy (15 steel 15 glass)
+  reward: 2000 # Vulp
   description: bounty-description-implanter
   entries:
   - name: bounty-item-implanter
-    amount: 3
+    amount: 4 # Vulp
     whitelist:
       components:
       - Implanter
@@ -150,7 +150,7 @@
   description: bounty-description-bloodpack
   entries:
   - name: bounty-item-bloodpacks
-    amount: 5 # Vulp - actually annoying because nobody does the microwave recipe
+    amount: 5
     whitelist:
       tags:
       - Bloodpack

--- a/Resources/Prototypes/_Floof/Catalog/Cargo/cargo_lewd.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Cargo/cargo_lewd.yml
@@ -4,7 +4,7 @@
     sprite: _Floof/Objects/Fun/Lewd/lewd_icons.rsi
     state: dildo
   product: CrateLewdToys
-  cost: 1000
+  cost: 2950 # Vulp
   category: cargoproduct-category-name-fun
   group: market
 
@@ -14,6 +14,6 @@
     sprite: _Floof/Objects/Fun/Lewd/Weapons/crotch_pink.rsi
     state: icon
   product: CrateLewdKink
-  cost: 1000
+  cost: 2950 # Vulp
   category: cargoproduct-category-name-fun
   group: market

--- a/Resources/Prototypes/_Vulp/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Vulp/Catalog/Bounties/bounties.yml
@@ -1,0 +1,12 @@
+#Misc
+
+- type: cargoBounty
+  id: BountyGhostSheet # kinda just to replace the bedsheet bounty if it does get removed
+  reward: 4100
+  description: bounty-description-ghostsheet
+  entries:
+  - name: bounty-item-ghostsheet
+    amount: 3
+    whitelist:
+      tags:
+      - GhostSheet

--- a/Resources/Prototypes/_Vulp/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Vulp/Catalog/Bounties/bounties.yml
@@ -1,9 +1,10 @@
 #Misc
 
 - type: cargoBounty
-  id: BountyGhostSheet # kinda just to replace the bedsheet bounty if it does get removed
-  reward: 4100
+  id: BountyGhostSheet
+  reward: 3200 # spoooooky profit margin
   description: bounty-description-ghostsheet
+  idPrefix: CC
   entries:
   - name: bounty-item-ghostsheet
     amount: 3

--- a/Resources/Prototypes/_Vulp/tags.yml
+++ b/Resources/Prototypes/_Vulp/tags.yml
@@ -3,3 +3,6 @@
 
 - type: Tag
   id: BlueshieldSabre
+
+- type: Tag
+  id: GhostSheet

--- a/Resources/Prototypes/_Vulp/tags.yml
+++ b/Resources/Prototypes/_Vulp/tags.yml
@@ -6,3 +6,6 @@
 
 - type: Tag
   id: GhostSheet
+
+- type: Tag
+  id: KoboldCube


### PR DESCRIPTION
# Description

There's some cargo bounties that don't mesh super well with colonist/planet-survival maps so I made some edits and comments with my personal ideas. The bounties as a whole are pretty inconsistent with cost and reward, which is fine since the randomness is part of the charm, buuut! There's a bunch that are just always skipped or ignored and tweaking their values might help!

I also added a "Ghost sheet" bounty because I saw it can be crafted with 5 cloth, so it kinda fits the void left by removing the bed-sheet bounty if we do that. The reward should probably be lower.

---

# TODO

- [x] Make initial tweaks and comments
- [x] Adjust based on feedback/discussion

---

# Changelog

:cl: Snowcat
- tweak: Adjusted cargo bounty requirements and rewards

