### PR TITLE
Give Remilia Nightvision

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -133,6 +133,10 @@
     thresholds:
       0: Alive
       30: Dead
+  - type: NightVision # Vulp - rem deserves to not be in pitch black at night. surely bats can see in the dark. echolocation or something
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
 
 - type: entity
   name: Cerberus


### PR DESCRIPTION
# Description

I was surprised to see that Remilia doesn't already have night-vision. It's not a stretch to imagine that a bat could see somewhat in the dark. This is a tiny thing that'll impact nobody but for the one player that likes Remilia shenanigans... 

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Snowcat
- add: The chaplain's familiar, Remilia, can now see in the dark