### PR TITLE
Fix Material Storage Eject Behavior 

### DIFF
--- a/Content.Server/Materials/MaterialStorageSystem.cs
+++ b/Content.Server/Materials/MaterialStorageSystem.cs
@@ -67,7 +67,7 @@ public sealed class MaterialStorageSystem : SharedMaterialStorageSystem
 
         var volume = 0;
 
-        if (material.StackEntity != null)
+        if (material.StackEntity != null) // Vulp - eject behavior no worky without stackEntity defined in the material
         {
             if (!_prototypeManager.Index<EntityPrototype>(material.StackEntity).TryGetComponent<PhysicalCompositionComponent>(out var composition))
                 return;

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -145,6 +145,7 @@
 
 - type: material
   id: Diamond
+  stackEntity: MaterialDiamond1 # Vulp - so MaterialStorageSystem handles eject behavior properly
   name: materials-diamond
   unit: materials-unit-piece
   icon: { sprite: Objects/Materials/materials.rsi, state: diamond }


### PR DESCRIPTION
# Description

You can add Refined Diamonds to material storages that have the RawMaterial tag whitelisted but you aren't able to eject them. I think this also happens with some other items, will look later.  

There should maybe be an error raised if this happens mainly because it took me over an HOUR to figure out as I'd assumed it was already handled in the MaterialDiamond entity itself but... no... skill issue on my part, maybe! 

---

# TODO


- [x] Fix Refined Diamond eject behavior 
- [ ] Check other relevant materials and fix in same fashion if needed

---

# Changelog

:cl: Snowcat
- fix: Fixed material eject behavior in lathes/flatpacker/etcetera

